### PR TITLE
ENH: remove intermediate copies in parsing

### DIFF
--- a/include/libpy/parser.h
+++ b/include/libpy/parser.h
@@ -3,6 +3,7 @@
 #include <algorithm>
 #include <array>
 #include <chrono>
+#include <memory>
 #include <sstream>
 #include <string>
 #include <type_traits>
@@ -36,41 +37,182 @@ position_formatted_error(std::size_t row, std::size_t col, Ts&&... msg) {
     return formatted_error("line ", row, " column ", col, ": ", std::forward<Ts>(msg)...);
 }
 
-namespace dispatch {
-/** Dispatched parser type to allow for partial template specialization.
+/** The state of the row parser, either quoted or not quoted.
  */
+enum class quote_state {
+    quoted,
+    not_quoted,
+};
+
+/** Error thrown when processing quoted cells fails.
+ */
+class quote_error : public std::runtime_error {
+public:
+    template<typename... Ts>
+    quote_error(Ts&&... msg)
+        : std::runtime_error(format_string(std::forward<Ts>(msg)...)) {}
+};
+
+class cell_parser {
+protected:
+    char m_delim;
+public:
+    cell_parser(char delim) : m_delim(delim) {}
+
+    virtual std::tuple<std::size_t, bool> chomp(const std::string_view&, std::size_t) = 0;
+
+    virtual py::scoped_ref<PyObject> move_to_python_tuple() && {
+        Py_INCREF(Py_None);
+        return py::scoped_ref(Py_None);
+    }
+};
+
 template<typename T>
-struct parse;
+struct typed_cell_parser : public cell_parser {
+protected:
+    std::vector<T> m_parsed;
+    std::vector<py::py_bool> m_mask;
+
+public:
+    using type = T;
+
+    typed_cell_parser(char delim) : cell_parser(delim) {}
+
+    const std::vector<T>& parsed() const {
+        return m_parsed;
+    }
+
+    py::scoped_ref<PyObject> move_to_python_tuple() && {
+        auto values = py::move_to_numpy_array(std::move(m_parsed));
+        if (!values) {
+            return nullptr;
+        }
+
+        auto mask_array = py::move_to_numpy_array(std::move(m_mask));
+        if (!mask_array) {
+            return nullptr;
+        }
+
+        return py::scoped_ref(PyTuple_Pack(2, values.get(), mask_array.get()));
+    }
+};
+
+template<typename F>
+std::tuple<std::size_t, bool>
+chomp_quoted_string(F&& f, char delim, const std::string_view& row, std::size_t offset) {
+    quote_state st = quote_state::not_quoted;
+        std::size_t started_quote;
+
+        auto cell = row.substr(offset);
+
+        std::size_t ix;
+        for (ix = 0; ix < cell.size(); ++ix) {
+            char c = cell[ix];
+
+            if (c == '\\') {
+                if (++ix == cell.size()) {
+                    throw formatted_error("line ",
+                                          cell,
+                                          ": row ends with escape character: ",
+                                          row);
+                }
+
+                f(cell[ix]);
+                continue;
+            }
+
+            switch (st) {
+            case quote_state::not_quoted:
+                if (c == '"') {
+                    st = quote_state::quoted;
+                    started_quote = ix;
+                }
+                else if (c == delim) {
+                    return {ix + 1, true};
+                }
+                else {
+                    f(cell[ix]);
+                }
+                break;
+            case quote_state::quoted:
+                if (c == '"') {
+                    st = quote_state::not_quoted;
+                }
+                else {
+                    f(cell[ix]);
+                }
+            }
+        }
+
+        if (st == quote_state::quoted) {
+            started_quote += offset;
+            std::string underline(started_quote + 2, ' ');
+            underline[0] = '\n';
+            underline[underline.size() - 1] = '^';
+            throw formatted_error("row ends while quoted, quote begins at index ",
+                                  started_quote,
+                                  ":\n",
+                                  row,
+                                  underline);
+        }
+
+        return {ix, false};
+}
 
 template<std::size_t n>
-struct parse<std::array<char, n>> {
-    static std::array<char, n> f(const std::string_view& data) {
-        std::array<char, n> out{0};
-        std::copy_n(data.begin(), std::min(out.size(), data.size()), out.begin());
-        return out;
+class char_array_parser : public typed_cell_parser<std::array<char, n>> {
+public:
+    char_array_parser(char delim) : typed_cell_parser<std::array<char, n>>(delim) {}
+
+    virtual std::tuple<std::size_t, bool> chomp(const std::string_view& row,
+                                                std::size_t offset) {
+        this->m_parsed.emplace_back(std::array<char, n>{0});
+        auto& cell = this->m_parsed.back();
+        std::size_t cell_ix = 0;
+        auto ret = chomp_quoted_string(
+            [&](char c) {
+                if (cell_ix < cell.size()) {
+                    cell[cell_ix++] = c;
+                }
+            },
+            this->m_delim,
+            row,
+            offset);
+        this->m_mask.emplace_back(cell_ix > 0);
+        return ret;
     }
 };
 
-template<>
-struct parse<double> {
-    static double f(const std::string_view& data) {
-        std::size_t pos;
-        double out;
-        try {
-            out = std::stod(std::string(data), &pos);
+class double_parser : public typed_cell_parser<double> {
+public:
+    double_parser(char delim) : typed_cell_parser<double>(delim) {}
+
+    virtual std::tuple<std::size_t, bool> chomp(const std::string_view& row, std::size_t offset) {
+        const char* first = &row.data()[offset];
+        char* last;
+        this->m_parsed.emplace_back(std::strtod(first, &last));
+
+        std::size_t size = last - first;
+        if (*last != this->m_delim && size != row.size() - offset) {
+            std::string_view cell;
+            auto end = std::memchr(first, this->m_delim, row.size() - offset);
+            if (end) {
+                cell = row.substr(offset, reinterpret_cast<const char*>(end) - first);
+            }
+            else {
+                cell = row.substr(offset);
+            }
+            throw formatted_error("invalid digit in double: ", cell);
         }
-        catch (const std::exception&) {
-            throw formatted_error("error in stod: ", data);
-        }
-        if (pos != data.size()) {
-            throw formatted_error("invalid digit in double: ", data);
-        }
-        return out;
+
+        this->m_mask.emplace_back(size > 0);
+
+        bool more = *last == this->m_delim;
+        return {size + more, more};
     }
 };
 
-template<>
-struct parse<py::datetime64ns> {
+class datetime64ns_parser : public typed_cell_parser<py::datetime64ns> {
 private:
     /** The number of days in each month for non-leap years.
      */
@@ -129,16 +271,36 @@ private:
     }
 
 public:
-    static py::datetime64ns f(const std::string_view& raw) {
+    datetime64ns_parser(char delim) : typed_cell_parser<py::datetime64ns>(delim) {}
+
+    virtual std::tuple<std::size_t, bool> chomp(const std::string_view& row,
+                                                std::size_t offset) {
+        std::string_view raw;
+
+        auto subrow = row.substr(offset);
+        const void* loc = std::memchr(subrow.data(), this->m_delim, subrow.size());
+        std::size_t size;
+        std::size_t consumed;
+        if (loc) {
+            size = reinterpret_cast<const char*>(loc) - subrow.data();
+            consumed = size + 1;
+        }
+        else {
+            size = consumed = subrow.size();
+        }
+
+        raw = subrow.substr(0, size);
         if (!raw.size()) {
-            return py::datetime64ns{};
+            this->m_parsed.emplace_back();
+            this->m_mask.emplace_back(false);
+            return {consumed, loc};
         }
 
         if (raw.size() != 10) {
             throw formatted_error("date string is not exactly 10 characters: ", raw);
         }
 
-        int year = parse_int<4>(raw.data());
+        int year = parse_int<4>(raw);
 
         if (raw[4] != '-') {
             throw formatted_error("expected hyphen at index 4: ", raw);
@@ -167,236 +329,138 @@ public:
 
         // adapt to a `std::chrono::time_point` to properly handle time unit
         // conversions and time since epoch
-        return std::chrono::system_clock::from_time_t(seconds);
+        this->m_parsed.emplace_back(std::chrono::system_clock::from_time_t(seconds));
+        this->m_mask.emplace_back(true);
+        return {consumed, loc};
     }
 };
 
-template<>
-struct parse<py::py_bool> {
-    static py::py_bool f(const std::string_view& data) {
-        if (data.size() != 1) {
-            throw formatted_error("bool is not 0 or 1: ", data);
-        }
+class bool_parser : public typed_cell_parser<py::py_bool> {
+public:
+    bool_parser(char delim) : typed_cell_parser<py::py_bool>(delim) {}
 
-        if (data[0] == '0') {
-            return false;
-        }
-        else if (data[0] == '1') {
-            return true;
+    virtual std::tuple<std::size_t, bool> chomp(const std::string_view& row,
+                                                std::size_t offset) {
+        std::size_t size;
+        std::size_t consumed;
+        auto subrow = row.substr(offset);
+        const void* loc = std::memchr(subrow.data(), this->m_delim, subrow.size());
+        if (loc) {
+            size = reinterpret_cast<const char*>(loc) - subrow.data();
+            consumed = size + 1;
         }
         else {
-            throw formatted_error("bool is not 0 or 1: ", data);
+            size = consumed = subrow.size();
         }
+
+        if (size == 0) {
+            this->m_parsed.emplace_back(false);
+            this->m_mask.emplace_back(false);
+            return {consumed, loc};
+        }
+        if (size != 1) {
+            throw formatted_error("bool is not 0 or 1: ", subrow.substr(0, size));
+        }
+
+        bool value;
+        if (subrow[0] == '0') {
+            value = false;
+        }
+        else if (subrow[0] == '1') {
+            value = true;
+        }
+        else {
+            throw formatted_error("bool is not 0 or 1: ", subrow[0]);
+        }
+
+        this->m_parsed.emplace_back(value);
+        this->m_mask.emplace_back(true);
+        return {consumed, loc};
     }
 };
-}  // namespace dispatch
 
-/** Parse the data as the given type.
-
-    @tparam T The type to parse as.
-    @param row The row index.
-    @param col The column index.
-    @param data The data to parse.
-    @return The parsed value.
- */
-template<typename T>
-T parse_element(const std::string_view& data) {
-    return dispatch::parse<T>::f(data);
-}
-
-/** Parse a value and set the mask.
-
-    @param out The output value vector.
-    @param mask The output mask.
-    @param data The data to parse.
- */
-template<typename T>
-void parse_element_into_vector(std::vector<T>& out,
-                               std::vector<py::py_bool>& mask,
-                               const std::string_view& data) {
-    if (data.size()) {
-        out.emplace_back(parse_element<T>(data));
-        mask.emplace_back(true);
-    }
-    else {
-        out.emplace_back(T{});
-        mask.emplace_back(false);
-    }
-}
-
-/** Marker type to indicate a column that should be ignored.
- */
-struct skip {};
-
-void parse_element_into_vector(const skip&,
-                               std::vector<py::py_bool>&,
-                               const std::string_view&) {}
-
-/** The type of a vector to store parsed values.
- */
-using value_vector = std::variant<std::vector<std::array<char, 1>>,
-                                  std::vector<std::array<char, 2>>,
-                                  std::vector<std::array<char, 3>>,
-                                  std::vector<std::array<char, 4>>,
-                                  std::vector<std::array<char, 6>>,
-                                  std::vector<std::array<char, 8>>,
-                                  std::vector<std::array<char, 9>>,
-                                  std::vector<std::array<char, 40>>,
-                                  std::vector<py::datetime64ns>,
-                                  std::vector<py::py_bool>,
-                                  std::vector<double>,
-                                  skip>;
-
-/** The type of the vector of (value, pair) tuples.
- */
-using vectors_type = std::vector<std::tuple<value_vector, std::vector<py::py_bool>>>;
-
-/** The state of the row parser, either quoted or not quoted.
- */
-enum class quote_state {
-    quoted,
-    not_quoted,
-};
-
-/** Error thrown when processing quoted cells fails.
- */
-class quote_error : public std::runtime_error {
+class header_parser : public cell_parser {
+protected:
+    std::vector<std::string> m_parsed;
 public:
-    template<typename... Ts>
-    quote_error(Ts&&... msg)
-        : std::runtime_error(format_string(std::forward<Ts>(msg)...)) {}
+    header_parser(char delim) : cell_parser(delim) {}
+
+    virtual std::tuple<std::size_t, bool> chomp(const std::string_view& row,
+                                                std::size_t offset) {
+        this->m_parsed.emplace_back();
+        auto& cell = this->m_parsed.back();
+        return chomp_quoted_string([&](char c) { cell.push_back(c); },
+                                   this->m_delim,
+                                   row,
+                                   offset);
+    }
+
+    const std::vector<std::string>& parsed() const {
+        return m_parsed;
+    }
 };
 
-/** Process cells with escaping.
+class skip_parser : public cell_parser {
+public:
+    skip_parser(char delim) : cell_parser(delim) {}
 
-    @param data The row to process.
-    @param delimiter The delimiter between cells.
-    @param f The function to call on each unquoted cell.
- */
-template<typename F>
-void process_quoted_cells(std::size_t row,
-                          const std::string_view& data,
-                          char delimiter,
-                          F&& f) {
-    std::string cell;
-    quote_state st = quote_state::not_quoted;
-
-    std::size_t started_quote;
-
-    for (std::size_t ix = 0; ix < data.size(); ++ix) {
-        char c = data[ix];
-
-        if (c == '\\') {
-            if (++ix == data.size()) {
-                throw formatted_error("line ",
-                                      row,
-                                      ": row ends with escape character: ",
-                                      data);
-            }
-
-            cell.push_back(data[ix]);
-            continue;
-        }
-
-        switch (st) {
-        case quote_state::not_quoted:
-            if (c == '"') {
-                st = quote_state::quoted;
-                started_quote = ix;
-            }
-            else if (c == delimiter) {
-                f(cell);
-                cell.clear();
-            }
-            else {
-                cell.push_back(c);
-            }
-            break;
-        case quote_state::quoted:
-            if (c == '"') {
-                st = quote_state::not_quoted;
-            }
-            else {
-                cell.push_back(c);
-            }
-        }
+    virtual std::tuple<std::size_t, bool> chomp(const std::string_view& row,
+                                                std::size_t offset) {
+        return chomp_quoted_string([](char) {}, this->m_delim, row, offset);
     }
-
-    f(cell);
-
-    if (st == quote_state::quoted) {
-        std::string underline(started_quote + 2, ' ');
-        underline[0] = '\n';
-        underline[underline.size() - 1] = '^';
-        throw formatted_error("line ",
-                              row,
-                              ": row ends while quoted, quote begins at index ",
-                              started_quote,
-                              ":\n",
-                              data,
-                              underline);
-    }
-}
+};
 
 /** Parse a single row and store the values in the vectors.
 
     @param row The row index.
     @param data The view over the row to parse.
-    @param delimiter The delimiter between cells.
-    @param vectors The output vectors.
+    @param parsers The cell parsers.
  */
 void parse_row(std::size_t row,
                const std::string_view& data,
-               char delimiter,
-               vectors_type& vectors) {
+               std::vector<std::unique_ptr<cell_parser>>& parsers) {
 
-    auto vectors_it = vectors.begin();
     std::size_t col = 0;
+    std::size_t consumed = 0;
+    bool more = true;
 
-    auto callback = [&](const std::string_view& cell) {
-        if (vectors_it == vectors.end()) {
+    for (auto& parser : parsers) {
+        if (!more) {
             throw formatted_error("line ",
                                   row,
-                                  ": more columns than expected, expected ",
-                                  vectors.size());
+                                  ": less columns than expected, got ",
+                                  col,
+                                  " but expected ",
+                                  parsers.size());
+        }
+        try {
+            auto [new_consumed, new_more] = parser->chomp(data, consumed);
+            consumed += new_consumed;
+            more = new_more;
+        }
+        catch (const std::exception& e) {
+            throw position_formatted_error(row, col, e.what());
         }
 
-        auto& [boxed_vector, mask] = *vectors_it++;
-        std::visit(
-            [&](auto& vector) {
-                try {
-                    parse_element_into_vector(vector, mask, cell);
-                }
-                catch (const std::exception& e) {
-                    throw position_formatted_error(row, col, e.what());
-                }
+        ++col;
+    }
 
-                ++col;
-            },
-            boxed_vector);
-    };
-
-    process_quoted_cells(row, data, delimiter, callback);
-
-    if (vectors_it != vectors.end()) {
+    if (consumed != data.size()) {
         throw formatted_error("line ",
                               row,
-                              ": less columns than expected, got ",
-                              std::distance(vectors.begin(), vectors_it),
-                              " but expected ",
-                              vectors.size());
+                              ": more columns than expected, expected ",
+                              parsers.size());
     }
 }
 
 /** Parse a full CSV given the header and the types of the columns.
 
-    @param vectors The output vectors.
     @param data The CSV to parse.
-    @param delimiter The delimiter between cells in a row.
+    @param parsers The cell parsers.
+    @param line_ending The string to split lines on.
  */
 void parse_csv_from_header(const std::string_view& data,
-                           vectors_type& vectors,
-                           char delimiter,
+                           std::vector<std::unique_ptr<cell_parser>>& parsers,
                            const std::string_view& line_ending) {
     // rows are 1 indexed for csv
     std::size_t row = 1;
@@ -408,7 +472,7 @@ void parse_csv_from_header(const std::string_view& data,
 
     while ((end = data.find(line_ending, pos)) != std::string_view::npos) {
         std::string_view line = data.substr(pos, end - pos);
-        parse_row(++row, line, delimiter, vectors);
+        parse_row(++row, line, parsers);
 
         // advance past line ending
         pos = end + line_ending.size();
@@ -417,7 +481,7 @@ void parse_csv_from_header(const std::string_view& data,
     std::string_view line = data.substr(pos);
     if (line.size()) {
         // get the rest of the data after the final newline if there is any
-        parse_row(++row, line, delimiter, vectors);
+        parse_row(++row, line, parsers);
     }
 }
 
@@ -433,15 +497,6 @@ bool dtype_eq(PyObject* a, py::scoped_ref<PyArray_Descr>& b) {
         throw std::runtime_error("failed to compare objects");
     }
     return result;
-}
-
-template<typename T>
-scoped_ref<PyObject> to_numpy_array(std::vector<T>& v) {
-    return py::move_to_numpy_array(std::move(v));
-}
-
-scoped_ref<PyObject> to_numpy_array(skip&) {
-    throw std::runtime_error("skipped column should not be converted to numpy array");
 }
 
 /** Python CSV parsing function.
@@ -460,6 +515,22 @@ PyObject* parse_csv(PyObject*,
                     const std::string_view& line_ending) {
     py::valgrind::callgrind profile("parse_csv");
 
+    if (PyDict_Size(dtypes) < 0) {
+        // ensure this is a dict with a reasonable error message
+        return nullptr;
+    }
+
+    auto line_end = data.find(line_ending, 0);
+    auto line = data.substr(0, line_end);
+
+    header_parser header_parser(delimiter);
+
+    for (auto [consumed, more] = std::make_tuple(0, true); more;) {
+        auto [new_consumed, new_more] = header_parser.chomp(line, consumed);
+        consumed += new_consumed;
+        more = new_more;
+    }
+
     std::array<py::scoped_ref<PyArray_Descr>, 11> possible_dtypes =
         {py::new_dtype<std::array<char, 1>>(),
          py::new_dtype<std::array<char, 2>>(),
@@ -474,51 +545,47 @@ PyObject* parse_csv(PyObject*,
          py::new_dtype<double>()};
 
     std::vector<py::scoped_ref<PyObject>> header;
-    vectors_type vectors;
+    std::vector<std::unique_ptr<cell_parser>> parsers;
 
-    auto line_end = data.find(line_ending, 0);
-    auto line = data.substr(0, line_end);
-
-    auto callback = [&](const std::string& cell) {
+    for (const auto& cell : header_parser.parsed()) {
         auto as_pystring = py::to_object(cell);
-        std::vector<py::py_bool> mask;
 
         PyObject* dtype = PyDict_GetItem(dtypes, as_pystring.get());
         if (!dtype) {
-            vectors.emplace_back(skip{}, mask);
+            parsers.emplace_back(std::make_unique<skip_parser>(delimiter));
         }
         else if (dtype_eq(dtype, possible_dtypes[0])) {
-            vectors.emplace_back(std::vector<std::array<char, 1>>{}, mask);
+            parsers.push_back(std::make_unique<char_array_parser<1>>(delimiter));
         }
         else if (dtype_eq(dtype, possible_dtypes[1])) {
-            vectors.emplace_back(std::vector<std::array<char, 2>>{}, mask);
+            parsers.push_back(std::make_unique<char_array_parser<2>>(delimiter));
         }
         else if (dtype_eq(dtype, possible_dtypes[2])) {
-            vectors.emplace_back(std::vector<std::array<char, 3>>{}, mask);
+            parsers.push_back(std::make_unique<char_array_parser<3>>(delimiter));
         }
         else if (dtype_eq(dtype, possible_dtypes[3])) {
-            vectors.emplace_back(std::vector<std::array<char, 4>>{}, mask);
+            parsers.push_back(std::make_unique<char_array_parser<4>>(delimiter));
         }
         else if (dtype_eq(dtype, possible_dtypes[4])) {
-            vectors.emplace_back(std::vector<std::array<char, 6>>{}, mask);
+            parsers.push_back(std::make_unique<char_array_parser<6>>(delimiter));
         }
         else if (dtype_eq(dtype, possible_dtypes[5])) {
-            vectors.emplace_back(std::vector<std::array<char, 8>>{}, mask);
+            parsers.push_back(std::make_unique<char_array_parser<8>>(delimiter));
         }
         else if (dtype_eq(dtype, possible_dtypes[6])) {
-            vectors.emplace_back(std::vector<std::array<char, 9>>{}, mask);
+            parsers.push_back(std::make_unique<char_array_parser<9>>(delimiter));
         }
         else if (dtype_eq(dtype, possible_dtypes[7])) {
-            vectors.emplace_back(std::vector<std::array<char, 40>>{}, mask);
+            parsers.push_back(std::make_unique<char_array_parser<40>>(delimiter));
         }
         else if (dtype_eq(dtype, possible_dtypes[8])) {
-            vectors.emplace_back(std::vector<py::datetime64ns>{}, mask);
+            parsers.emplace_back(std::make_unique<datetime64ns_parser>(delimiter));
         }
         else if (dtype_eq(dtype, possible_dtypes[9])) {
-            vectors.emplace_back(std::vector<py::py_bool>{}, mask);
+            parsers.emplace_back(std::make_unique<bool_parser>(delimiter));
         }
         else if (dtype_eq(dtype, possible_dtypes[10])) {
-            vectors.emplace_back(std::vector<double>{}, mask);
+            parsers.emplace_back(std::make_unique<double_parser>(delimiter));
         }
         else {
             py::raise(PyExc_TypeError) << "unknown dtype: " << dtype;
@@ -528,62 +595,54 @@ PyObject* parse_csv(PyObject*,
         header.emplace_back(std::move(as_pystring));
     };
 
-    process_quoted_cells(1, line, delimiter, callback);
-
-    Py_ssize_t dtypes_size = PyDict_Size(dtypes);
-    if (dtypes_size < 0) {
+    // Ensure that each key in dtypes has a corresponding column in the CSV header.
+    auto expected_keys = py::scoped_ref(PySet_New(dtypes));
+    if (!expected_keys) {
         return nullptr;
     }
-
-    // Ensure that each key in dtypes has a corresponding column in the CSV header.
-    auto keys = py::scoped_ref(PyDict_Keys(dtypes));
-    Py_ssize_t keys_count = PyList_Size(keys.get());
-    for (Py_ssize_t key_i = 0; key_i < keys_count; ++key_i) {
-        auto key = PyList_GetItem(keys.get(), key_i);
-
-        if (std::find_if(header.begin(), header.end(), [key](auto& str) {
-                return PyUnicode_Compare(str.get(), key) == 0;
-            }) == header.end()) {
-            auto pyheader = py::to_object(header);
-
-            py::raise(PyExc_ValueError)
-                << "dtype keys not present in header. dtype keys: " << keys
-                << " header: " << pyheader;
+    auto actual_keys = py::to_object(header);
+    if (!actual_keys) {
+        return nullptr;
+    }
+    auto actual_keys_set = py::scoped_ref(PySet_New(actual_keys.get()));
+    if (!actual_keys_set) {
+        return nullptr;
+    }
+    auto diff = py::scoped_ref(
+        PyNumber_Subtract(expected_keys.get(), actual_keys_set.get()));
+    if (!diff) {
+        return nullptr;
+    }
+    if (PySet_GET_SIZE(diff.get())) {
+        auto as_list = py::scoped_ref(PySequence_List(diff.get()));
+        if (PyList_Sort(as_list.get()) < 0) {
             return nullptr;
         }
+        py::raise(PyExc_ValueError) << "dtype keys not present in header: " << as_list
+                                    << "\nheader: " << actual_keys;
+        return nullptr;
     }
 
     // advance_past the line ending
     parse_csv_from_header(data.substr(line_end + line_ending.size()),
-                          vectors,
-                          delimiter,
+                          parsers,
                           line_ending);
 
     auto out = py::scoped_ref(PyDict_New());
     if (!out) {
         return nullptr;
     }
-    for (auto [name, values_and_mask] : py::zip(header, vectors)) {
-        auto& [boxed_vector, mask] = values_and_mask;
 
-        if (std::holds_alternative<skip>(boxed_vector)) {
-            continue;
-        }
+    for (std::size_t ix = 0; ix < header.size(); ++ix) {
+        auto& name = header[ix];
+        auto& parser = parsers[ix];
 
-        auto values = std::visit([](auto& vector) { return to_numpy_array(vector); },
-                                 boxed_vector);
-        if (!values) {
-            return nullptr;
-        }
-
-        auto mask_array = py::move_to_numpy_array(std::move(mask));
-        if (!mask_array) {
-            return nullptr;
-        }
-
-        auto value = py::scoped_ref(PyTuple_Pack(2, values.get(), mask_array.get()));
+        auto value = std::move(*parser).move_to_python_tuple();
         if (!value) {
             return nullptr;
+        }
+        if (value.get() == Py_None) {
+            continue;
         }
 
         if (PyDict_SetItem(out.get(), name.get(), value.get())) {


### PR DESCRIPTION
### premise
Currently, we are copying every cell one at a time before passing it to the parser for each column. This is very slow because we need to heap allocate and copy character by character to the heap, then copy that data back into one of the column's buffers. This change pushes cell boundary search into the parsers themselves so that they can choose to elide a copy or find the line delimiter in a natural way. Both parsing strings and doubles naturally yield the delimiter location so we don't need to first scan through the cell to find the end, then re-scan to parse the data. This gives us a tremendous performance improvement over both pandas.read_csv and our previous implementation.

### timing setup
I generated a fake CSV with the same schema as an ff_basic restated annual file. This file has 500,000 rows and 118 columns. The columns are:
```python
Counter({dtype('S6'): 1,
         dtype('<M8[ns]'): 7,
         dtype('S3'): 1,
         dtype('float64'): 105,
         dtype('S1'): 2,
         dtype('S2'): 1,
         dtype('S40'): 1})
```
```python
import io

import pandas as pd

from factset_fundamentals.common import Frequency, ZipFileKind
from factset_fundamentals.parser import parse_csv
from factset_fundamentals.schema import factset_tables

dtypes = factset_tables[ZipFileKind.basic, Frequency.restated_annual]
parse_dates = [k for k, v in dtypes.items() if v.kind == 'M']
sep = b'|'
line_ending = '\r\n'


with open('basic_r_af.csv', 'rb') as f:
    data = f.read()


buf = io.BytesIO(data)


def pandas():
    buf.seek(0)
    return pd.read_csv(
        buf,
        delimiter=sep,
        encoding='latin-1',
        escapechar='\\',
        parse_dates=parse_dates,
    )


def libpy():
    return parse_csv(data, dtypes, sep, line_ending)
```
<details>

```python

In [3]: len(data.splitlines())
Out[3]: 500001

In [4]: dtypes
Out[4]: 
{'FSYM_ID': dtype('S6'),
 'DATE': dtype('<M8[ns]'),
 'ADJDATE': dtype('<M8[ns]'),
 'CURRENCY': dtype('S3'),
 'FF_FPNC': dtype('float64'),
 'FF_UPD_TYPE': dtype('S1'),
 'FF_SALES': dtype('float64'),
 'FF_INT_INC': dtype('float64'),
 'FF_NON_INT_INC': dtype('float64'),
 'FF_GROSS_INC': dtype('float64'),
 'FF_OPER_EXP_OTH': dtype('float64'),
 'FF_OPER_EXP_TOT': dtype('float64'),
 'FF_OPER_INC': dtype('float64'),
 'FF_INT_EXP_TOT': dtype('float64'),
 'FF_LOAN_LOSS_PROV': dtype('float64'),
 'FF_NON_INT_EXP': dtype('float64'),
 'FF_PTX_XORD_CHRG': dtype('float64'),
 'FF_PTX_XORD_CR': dtype('float64'),
 'FF_PTX_INC': dtype('float64'),
 'FF_INC_TAX': dtype('float64'),
 'FF_MIN_INT_EXP': dtype('float64'),
 'FF_EQ_AFF_INC': dtype('float64'),
 'FF_NET_INCOME': dtype('float64'),
 'FF_DIV_PFD': dtype('float64'),
 'FF_CASH_ST': dtype('float64'),
 'FF_CASH_ONLY': dtype('float64'),
 'FF_CASH_DUE_FR_BK': dtype('float64'),
 'FF_BK_INVEST_TOT': dtype('float64'),
 'FF_PREM_RECEIV': dtype('float64'),
 'FF_RECEIV_TOT': dtype('float64'),
 'FF_INVEN': dtype('float64'),
 'FF_ASSETS_CURR': dtype('float64'),
 'FF_ASSETS_OTH_INTANG': dtype('float64'),
 'FF_INTANG': dtype('float64'),
 'FF_ASSETS': dtype('float64'),
 'FF_DEPS': dtype('float64'),
 'FF_LIABS_CURR': dtype('float64'),
 'FF_DEBT_ST': dtype('float64'),
 'FF_PAY_ACCT': dtype('float64'),
 'FF_ACCR_EXP_XPAYR': dtype('float64'),
 'FF_INS_LIABS_POL': dtype('float64'),
 'FF_DEBT_LT': dtype('float64'),
 'FF_PROV_RISK': dtype('float64'),
 'FF_DFD_TAX_ITC': dtype('float64'),
 'FF_LIABS_XMIN_INT_ACCUM': dtype('float64'),
 'FF_PFD_STK': dtype('float64'),
 'FF_COM_EQ': dtype('float64'),
 'FF_DEBT': dtype('float64'),
 'FF_DEBT_LT_CONV': dtype('float64'),
 'FF_SHLDRS_EQ': dtype('float64'),
 'FF_TIER1_CAP': dtype('float64'),
 'FF_TIER2_CAP': dtype('float64'),
 'FF_INT_PAY': dtype('float64'),
 'FF_SECS_CUSTODY': dtype('float64'),
 'FF_SECS_INVEST': dtype('float64'),
 'FF_NET_INC_CF': dtype('float64'),
 'FF_DEP_EXP_CF': dtype('float64'),
 'FF_DFD_TAX_CF': dtype('float64'),
 'FF_NON_CASH': dtype('float64'),
 'FF_FUNDS_OPER_GROSS': dtype('float64'),
 'FF_XORD_CF': dtype('float64'),
 'FF_WKCAP_CHG': dtype('float64'),
 'FF_ACQ_BUS_CF': dtype('float64'),
 'FF_LOAN_INCR_CF': dtype('float64'),
 'FF_LOAN_DECR_CF': dtype('float64'),
 'FF_SALE_ASSETS_BUS_CF': dtype('float64'),
 'FF_INVEST_ACTIV_CF': dtype('float64'),
 'FF_INVEST_SOURCES_CF': dtype('float64'),
 'FF_DIV_CF': dtype('float64'),
 'FF_DEPS_DECR_CF': dtype('float64'),
 'FF_DEPS_INCR_CF': dtype('float64'),
 'FF_FOR_EXCH_CF': dtype('float64'),
 'FF_CHG_CASH_CF': dtype('float64'),
 'FF_EBIT_OPER_PS': dtype('float64'),
 'FF_EPS_REPORTED': dtype('float64'),
 'FF_BPS': dtype('float64'),
 'FF_COM_SHS_OUT_EPS_BASIC': dtype('float64'),
 'FF_COM_SHS_OUT_EPS_DIL': dtype('float64'),
 'FF_COM_SHS_OUT': dtype('float64'),
 'FF_PRICE_CLOSE_FP': dtype('float64'),
 'FF_INVEST_YLD_5YAVG': dtype('float64'),
 'FF_ACTG_STANDARD': dtype('S2'),
 'FF_FY_LENGTH_DAYS': dtype('float64'),
 'FF_CONSOL_NET_INC': dtype('float64'),
 'FF_EQ_TOT': dtype('float64'),
 'FF_INCR_FED_HOME_ADV_CF': dtype('float64'),
 'FF_EPS_BASIC': dtype('float64'),
 'FF_COM_SHS_OUT_EPS': dtype('float64'),
 'FF_EXP_TOT': dtype('float64'),
 'FF_NOTES_RECEIV_LT': dtype('float64'),
 'FF_PAY_TAX': dtype('float64'),
 'FF_DFD_TAX': dtype('float64'),
 'FF_MIN_INT_ACCUM': dtype('float64'),
 'FF_LIABS_SHLDRS_EQ': dtype('float64'),
 'FF_LOAN_NET': dtype('float64'),
 'FF_INVEST_AFF': dtype('float64'),
 'FF_CUST_ACCEPT': dtype('float64'),
 'FF_INVEST_RE': dtype('float64'),
 'FF_PPE_NET': dtype('float64'),
 'FF_RSRV_NONEQ': dtype('float64'),
 'FF_DEPS_CUST': dtype('float64'),
 'FF_RECEIV_ST': dtype('float64'),
 'FF_ADJ_NET_OTH': dtype('float64'),
 'FF_DIV_PAY_OUT_PS': dtype('float64'),
 'FF_RSRV_CHG': dtype('float64'),
 'FF_DFD_TAX_DB': dtype('float64'),
 'FF_DFD_TAX_CR': dtype('float64'),
 'FF_RECEIV_INT': dtype('float64'),
 'FF_EPS_RPT_DATE': dtype('<M8[ns]'),
 'FF_SOURCE_IS_DATE': dtype('<M8[ns]'),
 'FF_SOURCE_BS_DATE': dtype('<M8[ns]'),
 'FF_SOURCE_CF_DATE': dtype('<M8[ns]'),
 'FF_CASH_RESTR': dtype('float64'),
 'FF_COM_EQ_RETAIN_EARN': dtype('float64'),
 'FF_SOURCE_DOC': dtype('S40'),
 'FF_REPORT_FREQ_CODE': dtype('S1'),
 'FF_FISCAL_DATE': dtype('<M8[ns]'),
 'FF_FYR': dtype('float64')}
```

</details>

### timings
```python
In [1]: %timeit pandas()
18.2 s ± 1.6 s per loop (mean ± std. dev. of 7 runs, 1 loop each)

In [2]: %timeit libpy()
8.57 s ± 358 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
```