### PR TITLE
Parallel parser

### DIFF
--- a/include/libpy/gil.h
+++ b/include/libpy/gil.h
@@ -77,4 +77,6 @@ public:
         }
     };
 };
+
+thread_local PyThreadState* gil::m_save;
 }  // namespace py


### PR DESCRIPTION
builds on the last change. Using the same setup as the last change but increasing the row count to 4 million (8 times more data):

```
In [2]: %time _ = libpy()
CPU times: user 2min 19s, sys: 872 ms, total: 2min 20s
Wall time: 26.3s

In [3]: %time _ = pandas()
CPU times: user 2min 5s, sys: 15.1 s, total: 2min 20s
Wall time: 2min 20s
```

This is tested on the factset dataloader test instance with 7 cores being used.

NOTE: I switched to `-march=native -mtune=native` because we are compiling on the same box that the code runs. This gave me about an 8% speedup.
