### PR TITLE
ENH: add char_sequence literals

### DIFF
--- a/include/libpy/char_sequence.h
+++ b/include/libpy/char_sequence.h
@@ -10,6 +10,13 @@ namespace py::cs {
 template<char... cs>
 using char_sequence = std::integer_sequence<char, cs...>;
 
+inline namespace literals {
+template<typename Char, Char... cs>
+constexpr char_sequence<cs...> operator""_cs() {
+    return {};
+}
+};
+
 namespace detail {
 template<char... cs, char... ds>
 constexpr auto binary_cat(char_sequence<cs...>, char_sequence<ds...>) {


### PR DESCRIPTION
makes it so we can write things like:

```c++
using type = decltype("ticker_region"_cs);
```
instead of:
```c++
using type = py::cs::char_sequence<'t', 'i', 'c', 'k', 'e', 'r', '_', 'r', 'e', 'g', 'i', 'o', 'n'>;
```