### PR TITLE
BUG: Convert char arrays to bytes instead of unicode

### DIFF
--- a/include/libpy/to_object.h
+++ b/include/libpy/to_object.h
@@ -42,7 +42,7 @@ namespace dispatch {
 template<std::size_t n>
 struct to_object<std::array<char, n>> {
     static PyObject* f(const std::array<char, n>& cs) {
-        return PyUnicode_FromStringAndSize(cs.data(), n);
+        return PyBytes_FromStringAndSize(cs.data(), n);
     }
 };
 


### PR DESCRIPTION
Using PyUnicode_FromStringAndSize fails if the input contains any
non-Unicode-encoded characters. Use PyUnicode_FromStringAndSize to
return bytes instead.