### PR TITLE
BUG: fix negative strides

### DIFF
--- a/include/libpy/array_view.h
+++ b/include/libpy/array_view.h
@@ -535,16 +535,16 @@ protected:
     char* m_buffer;
     any_ref_assign_func m_assign;
 
-    std::size_t pos_to_index(const std::array<std::size_t, ndim>& pos) const {
-        std::size_t ix = 0;
+    std::ptrdiff_t pos_to_index(const std::array<std::size_t, ndim>& pos) const {
+        std::ptrdiff_t ix = 0;
 
         for (std::size_t n = 0; n < ndim; ++n) {
-            std::size_t along_axis;
+            std::ptrdiff_t along_axis;
             if (__builtin_mul_overflow(pos[n], m_strides[n], &along_axis)) {
-                throw std::overflow_error("pos * m_strides overflows std::size_t");
+                throw std::overflow_error("pos * m_strides overflows std::ptrdiff_t");
             }
             if (__builtin_add_overflow(ix, along_axis, &ix)) {
-                throw std::overflow_error("ix + along_axis overflows std::size_t");
+                throw std::overflow_error("ix + along_axis overflows std::ptrdiff_t");
             }
         }
 

--- a/tests/test_array_view.cc
+++ b/tests/test_array_view.cc
@@ -250,4 +250,25 @@ TEST(any_ref_array_view, test_cast) {
         EXPECT_EQ(a.cast<int>(), c);
     }
 }
+
+TEST(any_ref_ndarray_view, negative_strides) {
+    std::array<int, 5> arr = {1, 2, 3, 4, 5};
+    py::array_view<py::any_ref> reverse_view(reinterpret_cast<char*>(&arr.back()),
+                                             {5},
+                                             {-static_cast<std::int64_t>(sizeof(int))},
+                                             py::any_ref_assign<int>);
+
+    EXPECT_EQ(reverse_view[0].cast<int>(), arr[arr.size() - 1]);
+    EXPECT_EQ(reverse_view[1].cast<int>(), arr[arr.size() - 2]);
+    EXPECT_EQ(reverse_view[2].cast<int>(), arr[arr.size() - 3]);
+    EXPECT_EQ(reverse_view[3].cast<int>(), arr[arr.size() - 4]);
+    EXPECT_EQ(reverse_view[4].cast<int>(), arr[arr.size() - 5]);
+
+    // check the iterator properly decrements the pointer
+    std::size_t ix = 0;
+    for (const auto& value : reverse_view) {
+        EXPECT_EQ(value.cast<int>(), arr[arr.size() - ix++ - 1]);
+    }
+
+}
 }  // namespace test_array_view


### PR DESCRIPTION
Change pos_to_index to accumulate the pointer offset into a std::ptrdiff_t
instead of a std::size_t. A negative stride right now often triggers the int
overflow because it is cast to an unsigned value before the multiply.