### PR TITLE
Parse csv performance

### DIFF
--- a/include/libpy/csv.h
+++ b/include/libpy/csv.h
@@ -216,7 +216,7 @@ public:
         return py::scoped_ref(PyTuple_Pack(2, values.get(), mask_array.get()));
     }
 
-    virtual std::tuple<std::vector<T>, std::vector<py::py_bool>> move_to_tuple() && {
+    std::tuple<std::vector<T>, std::vector<py::py_bool>> move_to_tuple() && {
         return {std::move(m_parsed), std::move(m_mask)};
     }
 };
@@ -292,8 +292,10 @@ template<std::size_t n>
 class typed_cell_parser<std::array<char, n>>
     : public typed_cell_parser_base<std::array<char, n>> {
 public:
-    virtual std::tuple<std::size_t, bool>
-    chomp(char delim, std::size_t ix, const std::string_view& row, std::size_t offset) {
+    std::tuple<std::size_t, bool> chomp(char delim,
+                                        std::size_t ix,
+                                        const std::string_view& row,
+                                        std::size_t offset) override {
         auto& cell = this->m_parsed[ix];
         std::size_t cell_ix = 0;
         auto ret = detail::chomp_quoted_string(
@@ -324,8 +326,10 @@ class fundamental_parser : public typed_cell_parser_base<parse_result<scalar_par
 public:
     using type = typename typed_cell_parser_base<parse_result<scalar_parse>>::type;
 
-    virtual std::tuple<std::size_t, bool>
-    chomp(char delim, std::size_t ix, const std::string_view& row, std::size_t offset) {
+    std::tuple<std::size_t, bool> chomp(char delim,
+                                        std::size_t ix,
+                                        const std::string_view& row,
+                                        std::size_t offset) override {
         const char* first = &row.data()[offset];
         const char* last;
         type parsed = scalar_parse(first, &last);
@@ -711,8 +715,10 @@ private:
     }
 
 public:
-    virtual std::tuple<std::size_t, bool>
-    chomp(char delim, std::size_t ix, const std::string_view& row, std::size_t offset) {
+    std::tuple<std::size_t, bool> chomp(char delim,
+                                        std::size_t ix,
+                                        const std::string_view& row,
+                                        std::size_t offset) override {
         auto [raw, consumed, more] = detail::isolate_unquoted_cell(row, offset, delim);
         if (!raw.size()) {
             return {consumed, more};
@@ -736,8 +742,10 @@ public:
 template<>
 class typed_cell_parser<py::py_bool> : public typed_cell_parser_base<py::py_bool> {
 public:
-    virtual std::tuple<std::size_t, bool>
-    chomp(char delim, std::size_t ix, const std::string_view& row, std::size_t offset) {
+    std::tuple<std::size_t, bool> chomp(char delim,
+                                        std::size_t ix,
+                                        const std::string_view& row,
+                                        std::size_t offset) override {
         auto [raw, consumed, more] = detail::isolate_unquoted_cell(row, offset, delim);
         if (raw.size() == 0) {
             return {consumed, more};
@@ -768,8 +776,10 @@ protected:
     std::vector<std::string> m_parsed;
 
 public:
-    virtual std::tuple<std::size_t, bool>
-    chomp(char delim, std::size_t, const std::string_view& row, std::size_t offset) {
+    std::tuple<std::size_t, bool> chomp(char delim,
+                                        std::size_t,
+                                        const std::string_view& row,
+                                        std::size_t offset) override {
         this->m_parsed.emplace_back();
         auto& cell = this->m_parsed.back();
         return detail::chomp_quoted_string([&](char c) { cell.push_back(c); },
@@ -785,8 +795,10 @@ public:
 
 class skip_parser : public cell_parser {
 public:
-    virtual std::tuple<std::size_t, bool>
-    chomp(char delim, std::size_t, const std::string_view& row, std::size_t offset) {
+    std::tuple<std::size_t, bool> chomp(char delim,
+                                        std::size_t,
+                                        const std::string_view& row,
+                                        std::size_t offset) override {
         return detail::chomp_quoted_string([](char) {}, delim, row, offset);
     }
 };


### PR DESCRIPTION
I just spent some time trying to optimize our CSV parser. Scott had noticed that
we were seeing either a slowdown or no improvement from passing more
threads. Upon investigation we realized that we were messing up the chunking so
the first thread parsed all of the lines, the second thread parsed all but the
leading expected chunksize rows, the third block parsed all but the leading 2 *
expected chunksize rows and so on. After correcting that, we saw an interesting
behavior: going from one thread to 2 threads was about a 30% speed up, but
adding more threads had no affect on the wall clock time. I wanted to try to dig
into why this was the case, and see if I could make better use of more threads,
at least on my machine. This is jumble a collection of notes from my
investigation of the CSV parser's performance.

# Test case

To do performance tuning, we need a test case to optimize. Our test case will be
parsing the first `fp_basic_prices_am` full from factset. This is a real, quite
large CSV that we actually received from factset. The file has the following
schema:

```python
basic_prices_schema = {
    b'FSYM_ID': np.dtype('S6'),
    b'P_DATE': np.dtype('datetime64[D]'),
    b'P_PRICE': np.dtype('float64'),
    b'P_PRICE_OPEN': np.dtype('float64'),
    b'P_PRICE_HIGH': np.dtype('float64'),
    b'P_PRICE_LOW': np.dtype('float64'),
    b'P_VOLUME': np.dtype('float64'),
}
```

It contains 60,230,000 rows and is around 3.1 GB. We will be timing the time it
takes to parse the file once it is already in memory, not including the time it
takes to read from disk. Factset delivers all the CSVs as compressed entries in
a zipfile, therefore we are never parsing a CSV directly from disk, we need to
decompress in memory before parsing, so this is a more realistic use
case. Optimizing the reading an decompression is important but a separate
problem.

### setting up the environment

I needed to make sure the test environment wasn't extremely volatile. To do
that, I closed almost everything on my computer (firefox, emacs, etc) when
running the tests. I also disabled esets and removed `libesets_pac.so` from my
`ld_preload` because these caused issues in profiling and would cause intel
vtune amplifier to segfault.

## First Hypothesis

My theory was that we were saturating the CPU's main memory bandwidth, meaning
we were executing instructions faster than the processor could retrieve the data
from main memory. If this was the case, the processor would be stalling (unable
to execute an instruction because the operands aren't yet available) and adding
more threads would not help.

We saw a dramatic speedup by building with `-DFACTSET_FAST_FLOAT` which switches
the CSV parser to use our own float parsing code instead of `std::strtod`. This
tells us that we are not memory bound yet, because we improved the CPU bound
part of the execution and the program got a lot faster. I wasn't sure if *now*
we were memory bound, which meant I didn't actually know what that limit was.

Next, I wanted to know the actual memory bandwidth on my CPU so I could tell if
the CSV parser was close to the limit. Then, I wanted to see how to observe the
affects of a memory stall. To do that I looked up my CPU model with:

```bash
$ lscpu | grep 'Model name'
Model name:          Intel(R) Core(TM) i7-6600U CPU @ 2.60GHz
```

and found the official specs here:
https://ark.intel.com/content/www/us/en/ark/products/88192/intel-core-i7-6600u-processor-4m-cache-up-to-3-40-ghz.html


```
Memory Types: DDR4-2133, LPDDR3-1866, DDR3L-1600
Max Memory Bandwidth: 34.1 GB/s
```

On my laptop, my ram is actually 1867 MHz, not the maximum possible which is
2133 MHz, therefore my theoretical max memory bandwidth is 29.8 GB/s instead of
34.1 GB/s. I then saw that Intel has a tool called `mlc` for measuring memory
bandwidth and latency with different read/write profiles and under load. `mlc`
is available here:
https://software.intel.com/en-us/articles/intelr-memory-latency-checker

```bash
$ sudo ./mlc_avx512
Intel(R) Memory Latency Checker - v3.6
Measuring idle latencies (in ns)...
		Numa node
Numa node	     0
       0	  64.0

Measuring Peak Injection Memory Bandwidths for the system
Bandwidths are in MB/sec (1 MB/sec = 1,000,000 Bytes/sec)
Using all the threads from each core if Hyper-threading is enabled
Using traffic with the following read-write ratios
ALL Reads        :	22043.6
3:1 Reads-Writes :	21263.5
2:1 Reads-Writes :	20966.7
1:1 Reads-Writes :	20908.6
Stream-triad like:	20881.4

Measuring Memory Bandwidths between nodes within system
Bandwidths are in MB/sec (1 MB/sec = 1,000,000 Bytes/sec)
Using all the threads from each core if Hyper-threading is enabled
Using Read-only traffic type
		Numa node
Numa node	     0
       0	22645.2

Measuring Loaded Latencies for the system
Using all the threads from each core if Hyper-threading is enabled
Using Read-only traffic type
Inject	Latency	Bandwidth
Delay	(ns)	MB/sec
==========================
 00000	113.92	  18753.5
 00002	108.31	  18857.0
 00008	100.96	  20223.7
 00015	100.28	  19566.2
 00050	 75.99	  12502.2
 00100	 69.44	   7763.0
 00200	 66.51	   4674.7
 00300	 65.07	   3557.3
 00400	 64.60	   2965.9
 00500	 64.16	   2593.8
 00700	 63.35	   2162.7
 01000	 66.23	   1773.8
 01300	 62.98	   1640.6
 01700	 62.81	   1497.3
 02500	 66.42	   1284.3
 03500	 65.69	   1206.0
 05000	 62.60	   1185.4
 09000	 62.81	   1109.6
 20000	 62.32	   1067.9

Measuring cache-to-cache transfer latency (in ns)...
Local Socket L2->L2 HIT  latency	22.4
Local Socket L2->L2 HITM latency	25.4
```

So it seems my actual peak bandwidth is closer to 22 GB/s (this number actually
moves a bit based on other stuff running on my computer).

To estimate the bandwidth required by our test case, I considered how much data we were
reading plus how much data we were writing.

```python
In [1]: import os, humanize, numpy as np

In [2]: reads = os.stat('fp_basic_prices_am_1.txt').st_size

In [3]: num_rows = 60230000

In [4]: basic_prices_schema = {
   ...:     b'FSYM_ID': np.dtype('S6'),
   ...:     b'P_DATE': np.dtype('datetime64[D]'),
   ...:     b'P_PRICE': np.dtype('float64'),
   ...:     b'P_PRICE_OPEN': np.dtype('float64'),
   ...:     b'P_PRICE_HIGH': np.dtype('float64'),
   ...:     b'P_PRICE_LOW': np.dtype('float64'),
   ...:     b'P_VOLUME': np.dtype('float64'),
   ...: }

In [5]: writes = sum(v.itemsize * num_rows for v in basic_prices_schema.values())

In [6]: writes += num_rows * len(basic_prices_schema)  # the is_missing masks

In [7]: total_rw = reads + writes

In [8]: humanize.naturalsize(total_rw)
Out[8]: '6.9 GB'
```

## Baseline Measurments

After cleaning up the partitioning issue, our baseline times were:

```
threads | time (s) | est. data bandwidth (MB/s)
      1 |    13.63 | 506.0
      2 |     9.43 | 731.2
      3 |     9.03 | 763.6
      4 |     9.16 | 752.8
```

So we don't seem to be all that close to the measured limit, what's slowing us
down? One thing to remember is that we read and write more than just the data
itself. We need to be loading code as well as our data structures to manipulate
the data. That extra overhead shouldn't add all that much relative to the data
(and if it is, we need to fix that).

## Measurement

`perf` is a linux specific tool that can read both the hardware event counters
on the processor and software counters set up by the kernel. You can even set up
your own counters for application specific monitoring, but the API looks very
low level (see `PERF_EVENT_OPEN(2)`). This tool let's you either statistically
sample, or collect traces when events occur to better understand the behavior of
a program.

We are going to be interested in a few events:

- `instructions`
- `cycles`
- `cycle_activity.stalls_mem_any`: cycles spent waiting for operands
- `icache_16b.ifdata_stall`: cycles spent waiting for instructions
- `L1-dcache-load-misses`: L1 data cache load misses
- `L1-icache-load-misses`: L1 instruction cache load misses
- `LLC-load-misses`: Last Level cache load misses.
- `context-switches`: How many times was the thread swapped of the CPU

NOTE: There are only so many counters on the processor, but they are
configurable. If you pass more events than you have space for, `perf` will
periodically swap which it is profiling. When this happens, the report will
contain a comment next to the measure like: `(85.75%)` which means that the
event was being watched for 87.75% of the program's execution. My processor
seems to have 4 configurable counters, but instructions and cycles don't count
towards that.

## LLC-cache-missses

Before we start checking for stalls and memory bandwidth stuff, we should make
sure we aren't getting a ton of LLC cache misses (non-predicted). This is the
slowest thing that can occur on the timescales we are looking to measure.


```bash
$ for threads in `seq 1 4`;do threads=$threads perf stat -e LLC-load-misses -- python csv_tests.py;done
(libpy) parse time (1 threads): 12.209 seconds

 Performance counter stats for 'python csv_tests.py':

        39,013,341      LLC-load-misses

      15.439678509 seconds time elapsed

      11.931627000 seconds user
       4.049856000 seconds sys


(libpy) parse time (2 threads): 8.3731 seconds

 Performance counter stats for 'python csv_tests.py':

        39,627,463      LLC-load-misses

      11.600705599 seconds time elapsed

      12.242830000 seconds user
       4.052021000 seconds sys


(libpy) parse time (3 threads): 8.4125 seconds

 Performance counter stats for 'python csv_tests.py':

        39,017,650      LLC-load-misses

      11.570377487 seconds time elapsed

      15.078357000 seconds user
       4.033469000 seconds sys


(libpy) parse time (4 threads): 8.4011 seconds

 Performance counter stats for 'python csv_tests.py':

        38,795,670      LLC-load-misses

      11.561164245 seconds time elapsed

      20.463309000 seconds user
       4.017182000 seconds sys
```

Okay, so they look about the same for all the thread counts. Let's run the single
threaded version and collect the stats to see where the LLC-cache misses are
happening. Remember, the reported time in the script is only the parsing, but we
are collecting stats on the whole processes including Python interpreter startup
and importing stuff.

```bash
$ threads=1 perf record -g -e LLC-load-misses -- python csv_tests.py
(libpy) parse time (1 threads): 11.897 seconds
[ perf record: Woken up 12 times to write data ]
[ perf record: Captured and wrote 3.137 MB perf.data (24435 samples) ]
$ perf report
```
NOTE: this is an tui program
```
Samples: 24K of event 'LLC-load-misses', Event count (approx.): 39268573
  Children      Self  Command   Shared Object                                Symbol
+   76.67%     0.00%  python    [kernel.vmlinux]                             [k] entry_SYS◆
+   76.67%     0.00%  python    [kernel.vmlinux]                             [k] do_syscal▒
+   56.92%     0.00%  python    libpthread-2.28.so                           [.] __libc_re▒
+   56.92%     0.00%  python    [kernel.vmlinux]                             [k] ksys_read▒
+   56.92%     0.00%  python    [kernel.vmlinux]                             [k] vfs_read ▒
+   56.92%     0.00%  python    [kernel.vmlinux]                             [k] __vfs_rea▒
+   56.91%     0.00%  python    [kernel.vmlinux]                             [k] generic_f▒
+   56.19%     0.00%  python    [kernel.vmlinux]                             [k] copy_page▒
+   56.19%     1.84%  python    [kernel.vmlinux]                             [k] copyout  ▒
+   54.34%    52.56%  python    [kernel.vmlinux]                             [k] copy_user▒
+   39.08%     0.00%  python    [unknown]                                    [k] 0x5441445▒
+   17.44%     0.00%  python    [unknown]                                    [k] 0x5038482▒
+   14.10%     0.23%  python    [kernel.vmlinux]                             [k] unmap_pag▒
+   14.10%     0.00%  python    [kernel.vmlinux]                             [k] unmap_vma▒
+   12.80%     0.00%  python    [kernel.vmlinux]                             [k] mmput    ▒
+   12.80%     0.00%  python    [kernel.vmlinux]                             [k] exit_mmap▒
+   10.03%     0.00%  python    [kernel.vmlinux]                             [k] __x64_sys▒
+   10.03%     0.00%  python    [kernel.vmlinux]                             [k] do_execve▒
+   10.03%     0.00%  python    [kernel.vmlinux]                             [k] __do_exec▒
+   10.03%     0.00%  python    libc-2.28.so                                 [.] __GI___ex▒
+   10.01%     0.00%  python    [kernel.vmlinux]                             [k] search_bi▒
+   10.01%     0.00%  python    [kernel.vmlinux]                             [k] load_elf_▒
+   10.01%     0.00%  python    [kernel.vmlinux]                             [k] flush_old▒
+    8.55%     0.00%  python    [kernel.vmlinux]                             [k] tlb_flush▒
Tip: If you prefer Intel style assembly, try: perf annotate -M intel                      ▒
```

We don't see our shared object in top list of LLC load misses. You can tell by
quickly scanning the "Shared Object" column. None of these are the code we
wrote. If we scroll down a little we can find the first occurrence of our own
code:

```
  Children      Self  Command   Shared Object                                Symbol
+    7.06%     5.14%  python    _parser.cpython-36m-x86_64-linux-gnu.so      [.] std::vect▒
```
This means about 7% of the LLC load misses happened here, let's annotate this
symbol to see what's up:

```
Samples: 24K of event 'LLC-load-misses', 4000 Hz, Event count (approx.): 39268573
std::vector<std::basic_string_view<char, std::char_traits<char> >, std::allocator<std::basi
Percent│             {
       │               _ForwardIterator __cur = __result;
       │               __try
       │                 {
       │                   for (; __first != __last; ++__first, (void)++__cur)
       │       cmp    %r14,%rbx
       │     → je     18584 <void std::vector<std::basic_string_view<char, std::char_traits
       │       mov    %r14,%rdx
       │               _ForwardIterator __cur = __result;
       │       mov    %r13,%rcx
       │       nop
  2.98 │       mov    (%rdx),%r9
 41.47 │       mov    0x8(%rdx),%r8
 18.87 │       add    $0x10,%rdx
       │                   for (; __first != __last; ++__first, (void)++__cur)
 11.36 │       add    $0x10,%rcx
  0.24 │       mov    %r9,-0x10(%rcx)
 10.43 │       mov    %r8,-0x8(%rcx)
 14.65 │       cmp    %rdx,%rbx
       │     → jne    18558 <void std::vector<std::basic_string_view<char, std::char_traits
       │       lea    -0x10(%rbx),%rax
       │       sub    %r14,%rax
       │       and    $0xfffffffffffffff0,%rax
       │       lea    0x20(%r13,%rax,1),%rax
Press 'h' for help on key bindings
```

So it looks like most of our own LLC load misses are in
`std::vector<std::basic_string>::_M_realloc_insert` which is the private method
that backs `insert`, `push_back`, and `emplace`. Note, `std::vector` is a
template, so this code is aggressively inlined which makes tracing the "source"
of a problem tricky. I pulled up this method to check what's going on here, and
it appears that `_M_realloc_insert` is called when a vector needs to resize. The
loop we see here:
```c++
for (; __first != __last; ++__first, (void)++__cur)
```
comes from the following code getting inlined through a few functions:
```c++
  template<bool _TrivialValueTypes>
    struct __uninitialized_copy
    {
      template<typename _InputIterator, typename _ForwardIterator>
        static _ForwardIterator
        __uninit_copy(_InputIterator __first, _InputIterator __last,
                      _ForwardIterator __result)
        {
          _ForwardIterator __cur = __result;
          __try
            {
              for (; __first != __last; ++__first, (void)++__cur)
                std::_Construct(std::__addressof(*__cur), *__first);
              return __cur;
            }
          __catch(...)
            {
              std::_Destroy(__result, __cur);
              __throw_exception_again;
            }
        }
    };
```

Basically, this is the loop that is copying all of the vector's elements from
the old allocation into the new, unitialized allocation. The vector that we are
building up here is `std::vector<std::string_view>` which represent each logical
line in the file. The caller of this is reading through all of the input text
and trying to break up all the lines and push them into this vector. Given that
we don't read them any of the lines until after we have collected *all* of them,
they will not stay in the cache very long and will be replaced by the source
text. It's not surprising that this data would be out of LL cache when we need
to grow the vector because that only happens a few times.

One idea for fixing this would be to grow our vector less. We don't know how
many lines we will need until we actually go count them, but we can use the
number of expected columns and the total size of the text to make a better
guess. Calling `_M_realloc_insert` less often will cause us to have less misses
here.

A complementary idea would be to accumulate the lines as just a vector of
`std::size_t` representing the length of the line. A `std::string_view` is a
pair of quadwords: a pointer to the start of the string and the size. Given that
we parse linearly, we can maintain the pointer to the start by just accumulating
the lengths of all the lines as we go. This would mean that our `lines` vector
takes up half the size and we can fit twice as many "lines" in a cache
line. This would both improve the efficiency of the `_M_realloc_insert` call,
but also improve the efficiency of our second pass through the lines when we
want to parse. For threaded parsing, we will also want to maintain a
"checkpoint" which is the base offset for the thread, but we can build that as
we split the lines.

## L1d-cache-misses

Now that we know where our last level cache misses are and have attempted to
correct them, let's check where our first level data cache misses occur:

```bash
$ for threads in `seq 1 4`;do threads=$threads perf stat -e L1-dcache-load-misses -- python csv_tests.py;done
(libpy) parse time (1 threads): 12.044 seconds

 Performance counter stats for 'python csv_tests.py':

       655,701,611      L1-dcache-load-misses

      15.112318716 seconds time elapsed

      11.751695000 seconds user
       3.902747000 seconds sys


(libpy) parse time (2 threads): 8.2664 seconds

 Performance counter stats for 'python csv_tests.py':

       669,638,184      L1-dcache-load-misses

      11.330914625 seconds time elapsed

      11.932229000 seconds user
       3.997971000 seconds sys


(libpy) parse time (3 threads): 8.3308 seconds

 Performance counter stats for 'python csv_tests.py':

       671,323,967      L1-dcache-load-misses

      11.398694339 seconds time elapsed

      14.892148000 seconds user
       3.958025000 seconds sys


(libpy) parse time (4 threads): 8.3217 seconds

 Performance counter stats for 'python csv_tests.py':

       735,187,671      L1-dcache-load-misses

      11.392113015 seconds time elapsed

      20.130219000 seconds user
       4.022543000 seconds sys
```

This seemed like interesting behavior to me. Why would adding more threads cause
more cache misses? One idea is that on my CPU, there are 4 "threads", but only 2
CPUs. Each CPU has a single L1 cache, so 2 threads running on the CPU could be
fighting over the rather small cache space. We want to be filling the cache with
the data to read and the locations to write, so we need to keep the parser
overhead low in terms of space occupied. Looking at our parser structs, we had
one big problem: the parsers are stored in a `std::unique_ptr` which refers to a
heap allocated value (random location). To correct this, we could allocate one
array of parsers on the stack and issue pointers our of this shared storage. We
don't know the type of the parsers statically, but the storage can be allocated
to be large enough to hold the largest type of parser (and all
`typed_cell_parsers` are the same size so there really isn't wasted space).

Now that the cell parsers are allocated in a contiguous array, we want to make
sure we can keep as many of them in a cache line as possible. This means we need
to consider the size of the cell parser structs themselves. On master, they
contained 3 fields: the vector of output values, the vector representing the
output mask, and the cell delimiter. Because the struct needed to be aligned for
the vectors, the cell delimiter was taking up an entire quadword, not just one
byte. If we have 8 columns, like in the pricing full case, this means we need
3 * 8 * 8 bytes to store all the parsers. This takes up 3 cache lines. Removing
the cell delimiter (and passing it in at the `chomp` callsite) reduces the size
to 2 * 8 * 8 which now fits in 2 cache lines. This scaling gets better the more
columns we want to load.

After updating, we see that we've improved our multi-threaded performance, but
the L1 dcache load misses have gone up.

```bash
$ for threads in `seq 1 4`;do threads=$threads perf stat -e L1-dcache-load-misses -- python csv_tests.py;done
(libpy) parse time (1 threads): 11.624 seconds

 Performance counter stats for 'python csv_tests.py':

       659,703,305      L1-dcache-load-misses

      14.943890963 seconds time elapsed

      11.656760000 seconds user
       3.837242000 seconds sys


(libpy) parse time (2 threads): 7.314 seconds

 Performance counter stats for 'python csv_tests.py':

       654,944,705      L1-dcache-load-misses

      10.642058352 seconds time elapsed

      13.046896000 seconds user
       3.851922000 seconds sys


(libpy) parse time (3 threads): 7.1674 seconds

 Performance counter stats for 'python csv_tests.py':

       688,272,128      L1-dcache-load-misses

      10.508274918 seconds time elapsed

      17.035099000 seconds user
       3.874637000 seconds sys


(libpy) parse time (4 threads): 7.3408 seconds

 Performance counter stats for 'python csv_tests.py':

       750,201,275      L1-dcache-load-misses

      10.885270504 seconds time elapsed

      23.369614000 seconds user
       4.050162000 seconds sys
```

Using `perf record` and `perf report` I noticed that we are still getting cache
misses in `split_into_lines_loop` and `fast_unsigned_strtod`. This tells me we
may want to try prefetching _before_ we call these functions to get the data we
need to read into the cache before we request it.

### prefetching

`split_into_lines` is the function which breaks up the source text into the
lines which we will later parse in parallel. The loop looks like:

```c++
void split_into_lines_loop(std::vector<std::size_t>& lines,
                           const std::string_view& data,
                           std::string_view::size_type* pos_ptr,
                           std::string_view::size_type end_ix,
                           const std::string_view& line_ending,
                           bool handle_tail) {
    auto pos = *pos_ptr;
    std::string_view::size_type end = data.find(line_ending, pos);
    if (pos != 0 && pos != end) {
        *pos_ptr = pos = end + line_ending.size();
    }

    while ((end = data.find(line_ending, pos)) != std::string_view::npos) {
        auto size = end - pos;
        lines.emplace_back(size);

        // advance past line ending
        pos = end + line_ending.size();

        if (pos >= end_ix) {
            break;
        }
    }

    if (handle_tail and pos < end_ix) {
        // add any data after the last newline if there is anything to add
        lines.emplace_back(end_ix - pos);
    }
}
```

This code wants to scan through `data` as fast as possible; however, we are not
exactly traversing it in fixed strides. We scan a little, do a vector insert,
then scan another variable amount and do a vector insert and so on. Here we can
add some prefetching to prepare the next few cache lines before we get to them
in the code:

```diff
diff --git a/include/libpy/csv.h b/include/libpy/csv.h
index 9bb4b3e..955a53e 100644
--- a/include/libpy/csv.h
+++ b/include/libpy/csv.h
@@ -882,6 +882,8 @@ void split_into_lines_loop(std::vector<std::size_t>& lines,

         // advance past line ending
         pos = end + line_ending.size();
+        __builtin_prefetch(data.data() + end + size, 0, 0);
+        __builtin_prefetch(data.data() + end + size + l1dcache_line_size, 0, 0);

         if (pos >= end_ix) {
             break;
```

The other place we see a lot of misses is in `fast_unsigned_strtod`. This means
we should try to prepare the data for parsing the cell before we get to the
`fast_unsigned_strtod` call. Here is the `parse_lines` loop that ultimately
calls `fast_unsigned_strtod`:

```c++
template<template<typename> typename ptr_type>
void parse_lines(const std::string_view data,
                 char delim,
                 std::size_t data_offset,
                 const std::vector<std::size_t>& line_sizes,
                 std::size_t line_end_size,
                 std::size_t offset,
                 parser_types<ptr_type>& parsers) {
    std::size_t ix = offset;
    for (const auto& size : line_sizes) {
        auto row = data.substr(data_offset, size);
        parse_row<ptr_type>(ix, delim, row, parsers);
        data_offset += size + line_end_size;
        ++ix;
    }
}
```

We can add a little prefetching for the _next_ row's data so that read can
happen while we are parsing the current row:

```diff
diff --git a/include/libpy/csv.h b/include/libpy/csv.h
index 469cad2..955a53e 100644
--- a/include/libpy/csv.h
+++ b/include/libpy/csv.h
@@ -830,6 +830,9 @@ void parse_lines(const std::string_view data,
     std::size_t ix = offset;
     for (const auto& size : line_sizes) {
         auto row = data.substr(data_offset, size);
+        __builtin_prefetch(row.data() + size, 0, 0);
+        __builtin_prefetch(row.data() + size + l1dcache_line_size, 0, 0);
+        __builtin_prefetch(row.data() + size + 2 * l1dcache_line_size, 0, 0);
         parse_row<ptr_type>(ix, delim, row, parsers);
         data_offset += size + line_end_size;
         ++ix;
```


```bash
$ for threads in `seq 1 4`;do threads=$threads perf stat -e L1-dcache-load-misses -- python csv_tests.py;done
(libpy) parse time (1 threads): 11.891 seconds

 Performance counter stats for 'python csv_tests.py':

       641,138,257      L1-dcache-load-misses

      15.200726930 seconds time elapsed

      11.840487000 seconds user
       3.889400000 seconds sys


(libpy) parse time (2 threads): 7.0286 seconds

 Performance counter stats for 'python csv_tests.py':

       626,078,750      L1-dcache-load-misses

      10.370772611 seconds time elapsed

      12.812260000 seconds user
       3.824805000 seconds sys


(libpy) parse time (3 threads): 7.1771 seconds

 Performance counter stats for 'python csv_tests.py':

       702,219,329      L1-dcache-load-misses

      10.577206399 seconds time elapsed

      17.178476000 seconds user
       3.850953000 seconds sys


(libpy) parse time (4 threads): 6.8914 seconds

 Performance counter stats for 'python csv_tests.py':

       760,827,137      L1-dcache-load-misses

      10.307933885 seconds time elapsed

      23.485403000 seconds user
       3.894551000 seconds sys
```

I am not really sure why our l1 dcache load misses went up for the higher thread
counts, but we see that we are running a bit faster with these prefetches for
more than a single core.


### PGO (not in this PR)

The last thing I wanted to look at was GCC's profile guided optimization
feature. PGO works by first compiling an instrumented version of your program
which records information. This program will be *much* slower, like 10x slower,
but it should be used to run a representative test suite. Then, you can feed
those stats back to GCC to produce a release version of your program. I used the
`fp_basic_prices_am_1.txt` file as the test case. I ran 4 times with 1-4
threads. The final times were:

```
(libpy) parse time (1 threads): 10.808 seconds
(libpy) parse time (2 threads): 6.5029 seconds
(libpy) parse time (3 threads): 6.5028 seconds
(libpy) parse time (4 threads): 6.4656 seconds
```

This is a crazy speedup for just an extra build step!

On my computer, it takes 2.5 seconds just to call `str.lower` on the raw input,
meaning we it only takes 2.6 times longer to parse the CSV than to call
`str.lower`.

Using the binary built for the large test case, I ran the small test case. This
also showed an impressive speedup, even though it was not exactly the same as
the test case:

```
(libpy) parse time (1 threads): 1.7498 seconds
(libpy) parse time (2 threads): 1.1276 seconds
(libpy) parse time (3 threads): 0.99433 seconds
(libpy) parse time (4 threads): 0.88703 seconds
```

On my laptop, it takes 554 milliseconds to call `str.lower` on the smaller raw
input. With 4 threads it only takes 1.57 times longer to parse the CSV than to
call `str.lower`. This seems crazy to me.
