### PR TITLE
ENH: remove overflow check to inline pos_to_index

### DIFF
--- a/include/libpy/ndarray_view.h
+++ b/include/libpy/ndarray_view.h
@@ -33,17 +33,9 @@ protected:
 
     std::ptrdiff_t pos_to_index(const std::array<std::size_t, ndim>& pos) const {
         std::ptrdiff_t ix = 0;
-
         for (std::size_t n = 0; n < ndim; ++n) {
-            std::ptrdiff_t along_axis;
-            if (__builtin_mul_overflow(pos[n], m_strides[n], &along_axis)) {
-                throw std::overflow_error("pos * m_strides overflows std::ptrdiff_t");
-            }
-            if (__builtin_add_overflow(ix, along_axis, &ix)) {
-                throw std::overflow_error("ix + along_axis overflows std::ptrdiff_t");
-            }
+            ix += pos[n] * m_strides[n];
         }
-
         return ix;
     }
 
@@ -471,17 +463,9 @@ protected:
 
     std::ptrdiff_t pos_to_index(const std::array<std::size_t, ndim>& pos) const {
         std::ptrdiff_t ix = 0;
-
         for (std::size_t n = 0; n < ndim; ++n) {
-            std::ptrdiff_t along_axis;
-            if (__builtin_mul_overflow(pos[n], m_strides[n], &along_axis)) {
-                throw std::overflow_error("pos * m_strides overflows std::ptrdiff_t");
-            }
-            if (__builtin_add_overflow(ix, along_axis, &ix)) {
-                throw std::overflow_error("ix + along_axis overflows std::ptrdiff_t");
-            }
+            ix += pos[n] * m_strides[n];
         }
-
         return ix;
     }
 


### PR DESCRIPTION
```c++
#include <benchmark/benchmark.h>
#include "libpy/ndarray_view.h"

std::array<double, (1 << 10)> arr = {0};
py::array_view<double> view(arr);

void bench_getitem_all(benchmark::State& state) {
    for (auto _ : state) {
        for (long ix = 0; ix < static_cast<long>(arr.size()); ++ix) {
            benchmark::DoNotOptimize(view[ix]);
        }
    }
}
BENCHMARK(bench_getitem_all);
```

master:
```
-------------------------------------------------------------------------
Benchmark                                  Time           CPU Iterations
-------------------------------------------------------------------------
bench_getitem_all                        744 ns        744 ns     931402
```

branch:
```
-------------------------------------------------------------------------
Benchmark                                  Time           CPU Iterations
-------------------------------------------------------------------------
bench_getitem_all                        636 ns        636 ns    1087744
```