### PR TITLE
ENH: add dict_range helper for iterating Python dicts

### DIFF
--- a/include/libpy/dict_range.h
+++ b/include/libpy/dict_range.h
@@ -1,0 +1,93 @@
+#pragma once
+
+#include <utility>
+
+#include <Python.h>
+
+#include "libpy/exception.h"
+#include "libpy/scoped_ref.h"
+
+namespace py {
+/** A range which iterates over the (key, value) pairs of a Python dictionary.
+ */
+class dict_range {
+private:
+    PyObject* m_map;
+
+    class iterator {
+    public:
+        using value_type = std::pair<PyObject*, PyObject*>;
+        using reference = value_type&;
+
+    private:
+        PyObject* m_map;
+        Py_ssize_t m_pos;
+        value_type m_item;
+
+    public:
+        iterator() : m_map(nullptr), m_pos(-1), m_item(nullptr, nullptr) {}
+
+        explicit iterator(PyObject* map) : m_map(map), m_pos(0) {
+            ++(*this);
+        }
+        iterator(const iterator&) = default;
+        iterator& operator=(const iterator&) = default;
+
+        reference operator*() {
+            return m_item;
+        }
+
+        value_type* operator->() {
+            return &m_item;
+        }
+
+        iterator& operator++() {
+            if (!PyDict_Next(m_map, &m_pos, &m_item.first, &m_item.second)) {
+                m_map = nullptr;
+                m_pos = -1;
+                m_item.first = nullptr;
+                m_item.second = nullptr;
+            }
+            return *this;
+        }
+
+        iterator operator++(int) {
+            iterator out = *this;
+            return ++out;
+        }
+
+        bool operator!=(const iterator& other) const {
+            return m_pos != other.m_pos;
+        }
+
+        bool operator==(const iterator& other) const {
+            return m_pos == other.m_pos;
+        }
+    };
+
+public:
+    explicit dict_range(PyObject* map) : m_map(map) {}
+    explicit dict_range(const py::scoped_ref<>& map) : dict_range(map.get()) {}
+
+    static dict_range checked(PyObject* map) {
+        if (!PyDict_Check(map)) {
+            throw py::exception(PyExc_TypeError,
+                                "argument to py::dict_range::checked isn't a dict, got: ",
+                                Py_TYPE(map)->tp_name);
+        }
+        return dict_range(map);
+    }
+
+    static dict_range checked(const py::scoped_ref<>& map) {
+        return checked(map.get());
+    }
+
+    iterator begin() const {
+        return iterator{m_map};
+    }
+
+    iterator end() const {
+        return iterator{};
+    }
+};
+}  // namespace py

--- a/tests/test_dict_range.cc
+++ b/tests/test_dict_range.cc
@@ -1,0 +1,73 @@
+#include <string>
+#include <unordered_map>
+
+#include "Python.h"
+#include "gtest/gtest.h"
+
+#include "libpy/dict_range.h"
+#include "libpy/exception.h"
+#include "test_utils.h"
+
+namespace test_dict_range {
+using namespace std::literals;
+
+class dict_range : public with_python_interpreter {};
+
+TEST_F(dict_range, iteration) {
+    py::scoped_ref ns = RUN_PYTHON(R"(
+        dict_0 = {}
+        dict_1 = {b'a': 1}
+        dict_2 = {b'a': 1, b'b': 2, b'c': 3}
+    )");
+    ASSERT_TRUE(ns);
+
+    {
+        PyObject* dict_0 = PyDict_GetItemString(ns.get(), "dict_0");
+        ASSERT_TRUE(dict_0);
+
+        for ([[maybe_unused]] auto item : py::dict_range(dict_0)) {
+            FAIL() << "empty dict should not enter the loop";
+        }
+    }
+
+    {
+        PyObject* dict_1 = PyDict_GetItemString(ns.get(), "dict_1");
+        ASSERT_TRUE(dict_1);
+
+        std::unordered_map<std::string, std::int64_t> expected = {{"a"s, 1}};
+        std::unordered_map<std::string, std::int64_t> actual;
+
+        for (auto [key, value] : py::dict_range(dict_1)) {
+            actual.emplace(py::from_object<std::string>(key),
+                           py::from_object<std::int64_t>(value));
+        }
+
+        EXPECT_EQ(actual, expected);
+    }
+
+    {
+        PyObject* dict_2 = PyDict_GetItemString(ns.get(), "dict_2");
+        ASSERT_TRUE(dict_2);
+
+        std::unordered_map<std::string, std::int64_t> expected = {{"a"s, 1},
+                                                                  {"b"s, 2},
+                                                                  {"c"s, 3}};
+        std::unordered_map<std::string, std::int64_t> actual;
+
+        for (auto [key, value] : py::dict_range(dict_2)) {
+            actual.emplace(py::from_object<std::string>(key),
+                           py::from_object<std::int64_t>(value));
+        }
+
+        EXPECT_EQ(actual, expected);
+    }
+}
+
+TEST_F(dict_range, not_a_dict) {
+    py::scoped_ref not_a_dict(PyList_New(0));
+    ASSERT_TRUE(not_a_dict);
+
+    EXPECT_THROW(py::dict_range::checked(not_a_dict), py::exception);
+    PyErr_Clear();
+}
+}  // namespace test_dict_range

--- a/tests/test_utils.h
+++ b/tests/test_utils.h
@@ -78,7 +78,9 @@ run_python(const std::string_view& python_source,
         if (!main_module) {
             throw py::exception();
         }
-        py::scoped_ref main_dict(PyModule_GetDict(main_module.get()));
+
+        // PyModule_GetDict returns a borrowed reference
+        PyObject* main_dict = PyModule_GetDict(main_module.get());
         if (!main_dict) {
             return nullptr;
         }
@@ -87,7 +89,7 @@ run_python(const std::string_view& python_source,
             return nullptr;
         }
 
-        if (PyDict_Update(python_namespace.get(), main_dict.get())) {
+        if (PyDict_Update(python_namespace.get(), main_dict)) {
             return nullptr;
         }
     }


### PR DESCRIPTION
Adds a small helper for iterating over the items of a Python dictionary, like `dict.items()`.

Example:

```c++
PyObject* my_dict = ...;

for (auto [key, value] : py::dict_range(my_dict)) {
    // ...
}
```