### PR TITLE
ENH: add dense_hash_set

### DIFF
--- a/include/libpy/exception.h
+++ b/include/libpy/exception.h
@@ -220,7 +220,13 @@ inline std::nullptr_t raise_from_cxx_exception(const std::exception& e) {
     PyObject* tb;
     PyErr_Fetch(&type, &value, &tb);
     Py_XDECREF(tb);
-    raise(type) << value << " (raised from C++ exception: " << e.what() << ")";
+    const char* what = e.what();
+    if (!what[0]) {
+        raise(type) << value << " (raised from C++ exception)";
+    }
+    else {
+        raise(type) << value << " (raised from C++ exception: " << e.what() << ')';
+    }
     Py_DECREF(type);
     Py_DECREF(value);
     return nullptr;

--- a/include/libpy/to_object.h
+++ b/include/libpy/to_object.h
@@ -233,9 +233,9 @@ struct to_object<std::vector<T>> {
     }
 };
 
-template<typename T>
-struct to_object<std::unordered_set<T>> {
-    static PyObject* f(const std::unordered_set<T>& s) {
+template<typename S>
+struct set_to_object {
+    static PyObject* f(const S& s) {
         py::scoped_ref out(PySet_New(nullptr));
 
         if (!out) {
@@ -255,6 +255,9 @@ struct to_object<std::unordered_set<T>> {
         return std::move(out).escape();
     }
 };
+
+template<typename T>
+struct to_object<std::unordered_set<T>> : set_to_object<std::unordered_set<T>> {};
 
 template<typename... Ts>
 struct to_object<std::tuple<Ts...>> {


### PR DESCRIPTION
expose google `dense_hash_set` with a constructor that requires an empty key.