### PR TITLE
ENH: have emplace_back forward arguments to the row constructor

### DIFF
--- a/include/libpy/table.h
+++ b/include/libpy/table.h
@@ -471,7 +471,7 @@ private:
 
     public:
         using difference_type = std::int64_t;
-        using value_type = row<columns...>;
+        using value_type = row<remove_const_column<columns>...>;
         using const_value_type = const value_type;
         using reference = row_view<columns...>;
         using const_reference = row<const_column<columns>...>;
@@ -716,8 +716,8 @@ public:
             [](const auto&... cs) {
                 return std::make_tuple(
                     py::array_view<
-                        typename std::remove_reference_t<decltype(cs)>::value_type>(cs)
-                        .freeze()...);
+                        const typename std::remove_reference_t<decltype(cs)>::value_type>(
+                        cs)...);
             },
             m_columns));
     }

--- a/tests/test_table.cc
+++ b/tests/test_table.cc
@@ -411,6 +411,34 @@ TEST(table, emplace_back) {
     test_row_3();
 }
 
+template<typename T>
+void test_row_iter(T& table) {
+    std::int64_t expected_a = 0;
+    double expected_b = 1.5;
+    custom_object expected_c(2);
+
+    for (auto row : table.rows()) {
+        auto& a = row.get("a"_cs);
+        auto& b = row.get("b"_cs);
+        auto& c = row.get("c"_cs);
+
+        if constexpr (std::is_const_v<T>) {
+            testing::StaticAssertTypeEq<decltype(a), const std::int64_t&>();
+            testing::StaticAssertTypeEq<decltype(b), const double&>();
+            testing::StaticAssertTypeEq<decltype(c), const custom_object&>();
+        }
+        else {
+            testing::StaticAssertTypeEq<decltype(a), std::int64_t&>();
+            testing::StaticAssertTypeEq<decltype(b), double&>();
+            testing::StaticAssertTypeEq<decltype(c), custom_object&>();
+        }
+
+        EXPECT_EQ(a, ++expected_a);
+        EXPECT_EQ(b, ++expected_b);
+        EXPECT_EQ(c, ++expected_c);
+    }
+}
+
 TEST(table, row_iter) {
     using T = py::table<py::C<std::int64_t>("a"_cs),
                         py::C<double>("b"_cs),
@@ -425,15 +453,8 @@ TEST(table, row_iter) {
         table.emplace_back(std::make_tuple(++a, ++b, ++c));
     }
 
-    std::int64_t expected_a = 0;
-    double expected_b = 1.5;
-    custom_object expected_c(2);
-
-    for (auto row : table.rows()) {
-        EXPECT_EQ(row.get("a"_cs), ++expected_a);
-        EXPECT_EQ(row.get("b"_cs), ++expected_b);
-        EXPECT_EQ(row.get("c"_cs), ++expected_c);
-    }
+    test_row_iter(table);
+    test_row_iter<const T>(table);
 }
 
 TEST(table_view, relabel) {


### PR DESCRIPTION
This makes it a little nicer to build up tables.

Also updates the table iterator a bit and adds tests around const iterators.