### PR TITLE
ENH: Add to and from object support for std::pair.

### DIFF
--- a/include/libpy/from_object.h
+++ b/include/libpy/from_object.h
@@ -11,6 +11,7 @@
 #include <type_traits>
 #include <unordered_map>
 #include <unordered_set>
+#include <utility>
 #include <vector>
 
 #include <Python.h>
@@ -353,6 +354,15 @@ public:
         }
 
         return fill_tuple(tup, std::index_sequence_for<Ts...>{});
+    }
+};
+
+template<typename T, typename U>
+struct from_object<std::pair<T, U>> {
+public:
+    static std::pair<T, U> f(PyObject* tup) {
+        std::tuple<T, U> tmp = from_object<std::tuple<T, U>>(tup);
+        return std::make_pair(std::get<0>(tmp), std::get<1>(tmp));
     }
 };
 

--- a/include/libpy/to_object.h
+++ b/include/libpy/to_object.h
@@ -8,6 +8,7 @@
 #include <type_traits>
 #include <unordered_map>
 #include <unordered_set>
+#include <utility>
 #include <vector>
 
 #include <Python.h>
@@ -293,6 +294,16 @@ public:
         }
 
         return std::move(out).escape();
+    }
+};
+
+template<typename T, typename U>
+struct to_object<std::pair<T, U>> {
+public:
+    static PyObject* f(const std::pair<T, U>& p) {
+        // Delegate to std::tuple dispatch.
+        return std::move(py::to_object(std::make_tuple(std::get<0>(p), std::get<1>(p))))
+            .escape();
     }
 };
 


### PR DESCRIPTION
Delegates to the existing implementation for std::tuple.