### PR TITLE
Any vector initialize fix

### DIFF
--- a/include/libpy/any_vector.h
+++ b/include/libpy/any_vector.h
@@ -369,6 +369,10 @@ private:
         if (m_vtable.is_trivially_copy_constructible()) {
             fill_constant_trivially_copyable(count, value);
         }
+        else if (m_vtable == py::any_vtable::make<py::scoped_ref<>>()) {
+            fill_constant_trivially_copyable(count, value.addr());
+            Py_REFCNT(value.addr()) += count;
+        }
         else {
             std::size_t itemsize = m_vtable.size();
             std::byte* data = m_storage;


### PR DESCRIPTION
Fix initializing from objects whose assignment operator tore down the existing object.

Adds performance optimization for initializing an any_vector of `scoped_ref`.