### PR TITLE
Get include paths using sysconfig

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,8 +27,11 @@ CXXFLAGS = -std=gnu++17 -g -O$(OPTLEVEL) \
 	-DPY_MAJOR_VERSION=$(PY_MAJOR_VERSION) \
 	-DPY_MINOR_VERSION=$(PY_MINOR_VERSION)
 
+# https://github.com/quantopian/libpy/pull/86/files#r309288697
 INCLUDE_DIRS := include/ \
-	$(shell $(PYTHON) -c "from distutils import sysconfig; print(sysconfig.get_config_var('INCLUDEPY'))") \
+	$(shell $(PYTHON) -c "import sysconfig; \
+						  print(sysconfig.get_path('include')); \
+						  print(sysconfig.get_path('platinclude'))") \
 	$(shell $(PYTHON) -c 'import numpy as np;print(np.get_include())')
 INCLUDE := $(foreach d,$(INCLUDE_DIRS), -I$d)
 


### PR DESCRIPTION
Fixes an osx issue where `python-config` was finding the wrong python version when using virtualenv.