### PR TITLE
ENH: add *_throws versions of call_function and call_method

### DIFF
--- a/include/libpy/call_function.h
+++ b/include/libpy/call_function.h
@@ -128,7 +128,7 @@ template<typename... Args>
 scoped_ref<> call_method_throws(PyObject* ob, const std::string& method, Args&&... args) {
     scoped_ref bound_method(PyObject_GetAttrString(ob, method.data()));
     if (!bound_method) {
-        return nullptr;
+        throw py::exception{};
     }
 
     return call_function_throws(bound_method.get(), std::forward<Args>(args)...);

--- a/tests/test_call_function.cc
+++ b/tests/test_call_function.cc
@@ -95,6 +95,13 @@ TEST_F(call_function, method_exception) {
     EXPECT_FALSE(result);
     expect_pyerr_type_and_message(PyExc_ValueError, "ayy lmao");
     PyErr_Clear();
+
+    // should still throw if the method doesn't exist
+    result = py::call_method(ob, "g");
+    EXPECT_FALSE(result);
+    expect_pyerr_type_and_message(PyExc_AttributeError,
+                                  "'C' object has no attribute 'g'");
+    PyErr_Clear();
 }
 
 class call_function_throws : public with_python_interpreter {};


### PR DESCRIPTION
Adding a version that throws makes it easier to chain calls, like:

```c++
py::call_method(py::call_method(ob, "f", 1), "g", 2);
```

If the first call (`ob.f(1)`) fails, the second call (`<res>.g(2)`) won't be attempted. This makes writing some code a little less verbose. Compare the above example to the safely expanded form:

```c++
auto result = py::call_method(ob, "f", 1);
if (!result) {
    return nullptr;
}
result = py::call_method(result, "g", 2)
if (!result) {
    return nullptr;
}
```