### PR TITLE
BUG: normalize exception before reading the value

### DIFF
--- a/src/exception.cc
+++ b/src/exception.cc
@@ -10,6 +10,7 @@ std::nullptr_t raise_from_cxx_exception(const std::exception& e) {
     PyObject* value;
     PyObject* tb;
     PyErr_Fetch(&type, &value, &tb);
+    PyErr_NormalizeException(&type, &value, &tb);
     Py_XDECREF(tb);
     const char* what = e.what();
     if (!what[0]) {


### PR DESCRIPTION
Some exceptions are not actually allocated until required to make it faster to
throw and catch exceptions inside the interpreter. There are a few cases I know
of where this happens:

- GeneratorExit being raised in a generator as the result of gen.close()
- KeyboardInterrupt being raised as the result of C-c

I caught this by having a C++ extension that called back into Python code, which
raised a KeyboardInterrupt, which, when we went to throw it back into Python,
wasn't initialized. The `type` was `PyExc_KeyboardInterrupt`, but the `value`
field was just `nullptr`.