### PR TITLE
BUG: disable copy construction of a `py::autoclass`.

### DIFF
--- a/include/libpy/autoclass.h
+++ b/include/libpy/autoclass.h
@@ -233,6 +233,13 @@ public:
         add_slot(Py_tp_dealloc, py_dealloc);
     }
 
+    // Delete the copy constructor, the intermediate string data points into
+    // storage that is managed by the type until `.type()` is called.
+    // Also, don't try to create 2 versions of the same type.
+    autoclass(const autoclass&) = delete;
+    autoclass(autoclass&&) = default;
+    autoclass& operator=(autoclass&&) = default;
+
     /** Add a `tp_traverse` field to this type. This is only allowed, but required if
         `extra_flags & Py_TPFLAGS_HAVE_GC`.
 


### PR DESCRIPTION
`py::autoclass` objects have internal pointers so the default copy constructor
isn't correct. While we could probably implement a complicated copy constructor,
it also doesn't really make sense because you can only construct a type once.