### PR TITLE
ENH: nested exceptions

### DIFF
--- a/include/libpy/exception.h
+++ b/include/libpy/exception.h
@@ -217,11 +217,14 @@ class exception : public std::exception {
 private:
     std::string m_msg;
 
+    static std::string msg_from_current_pyexc();
+
 public:
     /** Default constructor assumes that an exception has already been thrown.
      */
-    inline exception(const std::string& msg = "a Python exception occurred")
-        : m_msg(msg) {}
+    inline exception() : m_msg(msg_from_current_pyexc()) {}
+
+    inline exception(const std::string& msg) : m_msg(msg) {}
 
     /** Create a wrapping exception and raise it in Python.
 
@@ -230,7 +233,8 @@ public:
      */
     template<typename... Args>
     exception(PyObject* exc, Args&&... args) {
-        (raise(exc) << ... << args);
+        (raise(exc) << ... << std::forward<Args>(args));
+        m_msg = msg_from_current_pyexc();
     }
 
     inline const char* what() const noexcept override {

--- a/src/exception.cc
+++ b/src/exception.cc
@@ -1,9 +1,40 @@
 #include "libpy/exception.h"
 
 namespace py {
+namespace {
+void deep_what_recursive_helper(std::string& out, const std::exception& e, int level) {
+    if (level) {
+        out.push_back('\n');
+    }
+    out.insert(out.end(), level * 2, ' ');
+    const char* what = e.what();
+    if (*what) {
+        if (level) {
+            out += "raised from: ";
+        }
+        out += what;
+    }
+    else {
+        out += "raised from exception with empty what()";
+    }
+    try {
+        std::rethrow_if_nested(e);
+    }
+    catch (const std::exception& next) {
+        deep_what_recursive_helper(out, next, level + 1);
+    }
+}
+
+std::string deep_what(const std::exception& e) {
+    std::string out;
+    deep_what_recursive_helper(out, e, 0);
+    return out;
+}
+}  // namespace
+
 std::nullptr_t raise_from_cxx_exception(const std::exception& e) {
     if (!PyErr_Occurred()) {
-        py::raise(PyExc_RuntimeError) << "a C++ exception was raised: " << e.what();
+        py::raise(PyExc_RuntimeError) << "a C++ exception was raised: " << deep_what(e);
         return nullptr;
     }
     PyObject* type;
@@ -14,13 +45,34 @@ std::nullptr_t raise_from_cxx_exception(const std::exception& e) {
     Py_XDECREF(tb);
     const char* what = e.what();
     if (!what[0]) {
-        raise(type) << value << " (raised from C++ exception)";
+        raise(type) << value << "; raised from C++ exception";
     }
     else {
-        raise(type) << value << " (raised from C++ exception: " << what << ')';
+        raise(type) << value << "; raised from C++ exception: " << deep_what(e);;
     }
     Py_DECREF(type);
     Py_DECREF(value);
     return nullptr;
+}
+
+std::string exception::msg_from_current_pyexc() {
+    PyObject* type;
+    PyObject* value;
+    PyObject* tb;
+    PyErr_Fetch(&type, &value, &tb);
+    PyErr_NormalizeException(&type, &value, &tb);
+
+    py::scoped_ref as_str(PyObject_Str(value));
+    std::string out;
+    if (!as_str) {
+        out = "<failed to convert Python message to C++ message>";
+    }
+    else {
+        out = reinterpret_cast<PyTypeObject*>(type)->tp_name;
+        out += ": ";
+        out += py::util::pystring_to_string_view(as_str);
+    }
+    PyErr_Restore(type, value, tb);
+    return out;
 }
 }  // namespace py

--- a/tests/test_exception.cc
+++ b/tests/test_exception.cc
@@ -15,21 +15,21 @@ TEST_F(exception, raise_from_cxx) {
     py::raise_from_cxx_exception(std::runtime_error("msg2"));
     expect_pyerr_type_and_message(
         PyExc_RuntimeError,
-        "a C++ exception was raised: msg (raised from C++ exception: msg2)");
+        "a C++ exception was raised: msg; raised from C++ exception: msg2");
 
     PyErr_Clear();
 
     PyErr_SetString(PyExc_IndentationError, "pymsg");
     py::raise_from_cxx_exception(std::runtime_error("msg"));
     expect_pyerr_type_and_message(PyExc_IndentationError,
-                                  "pymsg (raised from C++ exception: msg)");
+                                  "pymsg; raised from C++ exception: msg");
 
     // Raising again should preserve existing error indicator type and append to the
     // message
     py::raise_from_cxx_exception(std::runtime_error("msg2"));
     expect_pyerr_type_and_message(
         PyExc_IndentationError,
-        "pymsg (raised from C++ exception: msg) (raised from C++ exception: msg2)");
+        "pymsg; raised from C++ exception: msg; raised from C++ exception: msg2");
 
     PyErr_Clear();
 }


### PR DESCRIPTION
Add support for nested exception messages being sent back to Python.
Improves the error messages produced by `py::exception{}` calls when read from
C++.