### PR TITLE
BUG: Invoke import_array as a macro rather than a function.

### DIFF
--- a/src/csv_parser.cc
+++ b/src/csv_parser.cc
@@ -16,9 +16,8 @@
 #endif
 
 namespace py::csv::parser {
-namespace {
-py::ensure_import_array_module_scope imported;
-}  // namespace
+
+IMPORT_ARRAY_MODULE_SCOPE();
 
 void cell_parser::set_num_lines(std::size_t) {}
 

--- a/src/csv_writer.cc
+++ b/src/csv_writer.cc
@@ -7,9 +7,13 @@
 #include "libpy/detail/csv_writer.h"
 #include "libpy/itertools.h"
 #include "libpy/stream.h"
+#include "libpy/numpy_utils.h"
 #include "libpy/util.h"
 
 namespace py::csv::writer {
+
+IMPORT_ARRAY_MODULE_SCOPE()
+
 namespace {
 /** A rope-backed buffer for building up CSVs in memory.
  */


### PR DESCRIPTION
When upgrading libpy in qexec, we say failures where the
ensure_import_array_module_scope constructor was invoked, but Py_Array_API was
NULL, which suggests that the function-based version of our import_array
automation code wasn't working properly. Moving it to a macro, which causes
import_array to be invoked "directly" inline in the scope of the macro, appears
to fix the issue, though I still don't totally understand why.

This also adds a missing invocation of import_array() in csv_writer.cc.