### PR TITLE
BUG: fix line counting

### DIFF
--- a/src/csv_parser.cc
+++ b/src/csv_parser.cc
@@ -591,6 +591,8 @@ split_into_lines(std::string_view data,
         // advance past line ending
         pos = end + line_ending.size();
     }
+
+    // advance past the skipped rows
     data = data.substr(pos);
     pos = 0;
 


### PR DESCRIPTION
Fix how we search for the last newline prior to the start of the thread.