### PR TITLE
BLD: Libpy marks its own headers + numpy headers as depends

### DIFF
--- a/libpy/build.py
+++ b/libpy/build.py
@@ -108,8 +108,8 @@ class LibpyExtension(setuptools.Extension, object):
             kwargs.get('extra_link_args', [])
         )
         depends = kwargs.setdefault('depends', [])
-        depends.append(glob.glob(get_include()+'/**/*.h', recursive=True))
-        depends.append(glob.glob(get_include()+'/**/*.h', recursive=True))
+        depends.append(glob.glob(get_include() + '/**/*.h', recursive=True))
+        depends.append(glob.glob(np.get_include() + '/**/*.h', recursive=True))
 
         include_dirs = kwargs.setdefault('include_dirs', [])
         include_dirs.append(get_include())


### PR DESCRIPTION
Closes https://github.com/quantopian/libpy/issues/124

Do we care about the list of depends being unique?
Do we care about the headers under `detail`?