### PR TITLE
TST: Add compiler macro test so we can make test on osx

### DIFF
--- a/include/libpy/numpy_utils.h
+++ b/include/libpy/numpy_utils.h
@@ -183,6 +183,13 @@ struct new_dtype<std::uint32_t> : new_dtype_from_typecode<NPY_UINT32> {};
 template<>
 struct new_dtype<std::uint64_t> : new_dtype_from_typecode<NPY_UINT64> {};
 
+#ifdef __APPLE__
+
+template<>
+struct new_dtype<long> : new_dtype_from_typecode<NPY_INT64> {};
+
+#endif
+
 template<>
 struct new_dtype<float> : new_dtype_from_typecode<NPY_FLOAT32> {};
 
@@ -257,7 +264,7 @@ private:
 public:
     static constexpr bool value = std::is_same_v<decltype(test<T>(0)), std::true_type>;
 };
-}
+}  // namespace detail
 
 /** Compile time boolean to detect if `new_dtype` works for a given type. This exists to
     make it easier to use `if constexpr` to test this condition instead of using more


### PR DESCRIPTION
We're still left with the `may be used uninitialized` errors:

```
D.786588]'In file included from tests/test_automethod.cc:9:
include/libpy/automethod.h: In function 'py::detail::automethodwrapper<&test_automethod::optional_arg, 0, void>(std::conditional<is_same_v<void, void>, _object*, void>::type, _object*, _object*)_object*':
include/libpy/automethod.h:412:50: error:  may be used uninitialized in this function [-Werror=maybe-uninitialized]
             return dispatch::adapt_argument<Arg>{};
                                                  ^
D.789003]'include/libpy/automethod.h: In function 'py::detail::argument_parser<py::arg::optional<py::arg::keyword<std::integer_sequence<char, (char)107, (char)119, (char)95, (char)97, (char)114, (char)103>, int> > >::parse(_object*, _object*)':
include/libpy/automethod.h:412:50: error:  may be used uninitialized in this function [-Werror=maybe-uninitialized]
             return dispatch::adapt_argument<Arg>{};
                                                  ^
D.790012]'include/libpy/automethod.h: In function 'py::detail::automethodwrapper<&test_automethod::req_then_optional_arg, 0, void>(std::conditional<is_same_v<void, void>, _object*, void>::type, _object*, _object*)_object*':
include/libpy/automethod.h:412:50: error:  may be used uninitialized in this function [-Werror=maybe-uninitialized]
             return dispatch::adapt_argument<Arg>{};
                                                  ^
cc1plus: all warnings being treated as errors
make: *** [tests/test_automethod.o] Error 1
```