### PR TITLE
DOC: Added link to build badge

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,8 +1,9 @@
-
-.. image:: https://github.com/quantopian/libpy/workflows/CI/badge.svg
-
 ``libpy``
 =========
+
+.. image:: https://github.com/quantopian/libpy/workflows/CI/badge.svg
+    :alt: GitHub Actions status
+    :target: https://github.com/quantopian/libpy/actions?query=workflow%3ACI
 
 Utilities for writing C++ extension modules for CPython.
 


### PR DESCRIPTION
and moved badge under the header

I would narrow the query to just master, but it looks like we're not currently running CI on master, just on PRs. Shall we fix that?